### PR TITLE
Fix/updated notification use case

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/LabResApplication.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/LabResApplication.kt
@@ -1,9 +1,11 @@
 package com.healthmetrix.labres
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 class LabResApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/healthmetrix/labres/lab/NotifyUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/NotifyUseCase.kt
@@ -1,27 +1,48 @@
 package com.healthmetrix.labres.lab
 
-import com.healthmetrix.labres.OrderId
 import com.healthmetrix.labres.logger
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 
 interface NotifyUseCase {
-    operator fun invoke(orderId: OrderId)
+    operator fun invoke(notificationId: String)
+}
+
+@ConfigurationProperties(prefix = "notification")
+@ConstructorBinding
+data class NotificationConfig(
+    val host: String,
+    val path: String,
+    val basicAuth: BasicAuth
+) {
+
+    data class BasicAuth(
+        val user: String,
+        val pass: String
+    )
 }
 
 @Component
 @Profile("notify")
 class NotifyD4LUseCase(
-    @Value("\${notification-endpoint}")
-    private val endpoint: String
+    private val config: NotificationConfig
 ) : NotifyUseCase {
-    override fun invoke(orderId: OrderId) {
+    override fun invoke(notificationId: String) {
         try {
-            WebClient.create().post().apply {
-                uri(endpoint)
-                bodyValue(orderId)
+            WebClient.create(config.host).post().uri { builder ->
+                builder.path(config.path)
+                builder.build(mapOf("notificationId" to notificationId))
+            }.headers { headers ->
+                if (config.basicAuth.user.isNotBlank() && config.basicAuth.pass.isNotBlank())
+                    headers.setBasicAuth(config.basicAuth.user, config.basicAuth.pass)
+                else {
+                    val userBlank = config.basicAuth.user.isBlank()
+                    val passBlank = config.basicAuth.pass.isBlank()
+                    logger.warn("Notification basic auth missing, user blank? $userBlank pass blank? $passBlank")
+                }
             }.retrieve().toBodilessEntity().block()
         } catch (ex: Exception) {
             logger.warn("Failed to notify", ex)
@@ -32,7 +53,7 @@ class NotifyD4LUseCase(
 @Component
 @Profile("!notify")
 class NotifyLogsUseCase : NotifyUseCase {
-    override fun invoke(orderId: OrderId) {
-        logger.info("Order number updated: $orderId")
+    override fun invoke(notificationId: String) {
+        logger.info("Notification sent with id $notificationId")
     }
 }

--- a/src/main/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCase.kt
@@ -1,6 +1,7 @@
 package com.healthmetrix.labres.lab
 
 import com.healthmetrix.labres.logger
+import com.healthmetrix.labres.order.Status
 import com.healthmetrix.labres.persistence.OrderInformationRepository
 import java.time.Instant
 import java.util.Date
@@ -26,9 +27,9 @@ class UpdateResultUseCase(
             )
         )
 
-        if (saved.notificationId != null)
+        if (saved.notificationId != null && saved.status != Status.IN_PROGRESS)
             notifier(saved.notificationId)
-        else
+        else if (saved.notificationId == null)
             logger.warn("No notification id for ${saved.id}")
 
         return UpdateStatusResponse.Success

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,12 @@ dynamo:
   table-name: order_information
   local-endpoint: http://localhost:8000
 
-notification-endpoint: http://localhost:8001
+notification:
+  host: http://localhost:8001
+  path: /notifications/{notificationId}
+  basic-auth:
+    user: # empty
+    pass: # empty
 
 ---
 spring:

--- a/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
@@ -67,4 +67,16 @@ class UpdateResultUseCaseTest {
             )
         }
     }
+
+    @Test
+    fun `orderInfos updated with a status of IN_PROGRESS do not notify`() {
+        every { orderInformationRepository.findByOrderNumber(any()) } returns orderInfo
+        every { orderInformationRepository.save(any()) } returns orderInfo.copy(status = Status.IN_PROGRESS)
+
+        underTest(labResult, Date.from(Instant.now()))
+
+        verify(exactly = 0) {
+            notifier(any())
+        }
+    }
 }

--- a/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
@@ -22,7 +22,8 @@ class UpdateResultUseCaseTest {
         id = UUID.randomUUID(),
         issuedAt = Date.from(Instant.now()),
         number = orderNumber,
-        status = Status.IN_PROGRESS
+        status = Status.IN_PROGRESS,
+        notificationId = "notificationId"
     )
 
     private val labResult = LabResult(orderNumber, "labId", Result.POSITIVE)
@@ -72,6 +73,17 @@ class UpdateResultUseCaseTest {
     fun `orderInfos updated with a status of IN_PROGRESS do not notify`() {
         every { orderInformationRepository.findByOrderNumber(any()) } returns orderInfo
         every { orderInformationRepository.save(any()) } returns orderInfo.copy(status = Status.IN_PROGRESS)
+
+        underTest(labResult, Date.from(Instant.now()))
+
+        verify(exactly = 0) {
+            notifier(any())
+        }
+    }
+    @Test
+    fun `orderInfos updated with no notification id do not notify`() {
+        every { orderInformationRepository.findByOrderNumber(any()) } returns orderInfo
+        every { orderInformationRepository.save(any()) } returns orderInfo.copy(notificationId = null)
 
         underTest(labResult, Date.from(Instant.now()))
 


### PR DESCRIPTION
- POST to a given host + path
- path has a `notificationId` variable that is substituted
- notifications are not sent without a notificationId
- notifications are not sent if status is IN_PROGRESS