### PR TITLE
Feature/40 type field

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -186,6 +186,10 @@ paths:
                 orderNumber:
                   type: string
                   description: The order number.
+                type:
+                  type: string
+                  description: The kind of test used to generate the given result.  The example is a LOINC code
+                  example: 94500-6
               required:
                 - result
                 - orderNumber

--- a/src/main/kotlin/com/healthmetrix/labres/lab/ExtractObxResultUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/ExtractObxResultUseCase.kt
@@ -3,9 +3,9 @@ package com.healthmetrix.labres.lab
 import com.healthmetrix.labres.order.OrderNumber
 import org.springframework.stereotype.Component
 
-const val RESULT_INDEX = 5
-const val TEST_TYPE_INDEX = 1000 // TODO when specified
-const val OBX_MESSAGE_SEPARATOR = "|"
+private const val RESULT_INDEX = 5
+private const val TEST_TYPE_INDEX = 1000 // TODO when specified
+private const val OBX_MESSAGE_SEPARATOR = "|"
 
 /**
  * A typical OBX Message looks like the following:

--- a/src/main/kotlin/com/healthmetrix/labres/lab/LabController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/LabController.kt
@@ -36,7 +36,14 @@ class LabController(
 
         val labId = extractLabIdUseCase(labIdHeader) ?: return UpdateStatusResponse.OrderNotFound.asEntity()
 
-        return updateResultUseCase(LabResult(orderNumber, labId, result.result)).asEntity()
+        val labResult = LabResult(
+            orderNumber = orderNumber,
+            labId = labId,
+            result = result.result,
+            testType = result.type
+        )
+
+        return updateResultUseCase(labResult).asEntity()
     }
 
     @PutMapping(
@@ -80,10 +87,16 @@ class LabController(
 
 data class JsonResult(
     val orderNumber: String,
-    val result: Result
+    val result: Result,
+    val type: String? = null
 )
 
-data class LabResult(val orderNumber: OrderNumber, val labId: String, val result: Result)
+data class LabResult(
+    val orderNumber: OrderNumber,
+    val labId: String,
+    val result: Result,
+    val testType: String?
+)
 
 enum class Result {
     POSITIVE,

--- a/src/main/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCase.kt
@@ -19,7 +19,11 @@ class UpdateResultUseCase(
         val orderInfo = orderInformationRepository.findByOrderNumber(labResult.orderNumber)
             ?: return UpdateStatusResponse.OrderNotFound
 
-        val update = orderInfo.copy(status = labResult.result.asStatus(), labId = labResult.labId)
+        val update = orderInfo.copy(
+            status = labResult.result.asStatus(),
+            labId = labResult.labId,
+            testType = labResult.testType
+        )
         if (update.status == Status.IN_PROGRESS) {
             orderInformationRepository.save(update.copy(enteredLabAt = now))
         } else {

--- a/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
@@ -19,7 +19,8 @@ data class OrderInformation(
     val reportedAt: Date? = null,
     val notifiedAt: Date? = null,
     val notificationId: String? = null,
-    val enteredLabAt: Date? = null
+    val enteredLabAt: Date? = null,
+    val testType: String? = null
 ) {
     internal fun raw() = RawOrderInformation(
         id = id,
@@ -29,7 +30,8 @@ data class OrderInformation(
         reportedAt = reportedAt,
         notifiedAt = notifiedAt,
         notificationId = notificationId,
-        enteredLabAt = enteredLabAt
+        enteredLabAt = enteredLabAt,
+        testType = testType
     )
 }
 
@@ -61,7 +63,10 @@ data class RawOrderInformation(
     var notificationId: String? = null,
 
     @DynamoDBAttribute
-    var enteredLabAt: Date? = null
+    var enteredLabAt: Date? = null,
+
+    @DynamoDBAttribute
+    var testType: String? = null
 ) {
     fun cook(): OrderInformation? {
         val id = id

--- a/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
@@ -116,6 +116,26 @@ class LabControllerTest {
                 status { isNotFound }
             }
         }
+
+        @Test
+        fun `uploading a document with the optional test type returns 200`() {
+            every { extractLabIdUseCase(any()) } returns "labId"
+            every { updateResultUseCase(any(), any()) } returns UpdateStatusResponse.Success
+
+            mockMvc.put("/v1/results/json") {
+                header(HttpHeaders.AUTHORIZATION, labIdHeader)
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(
+                    mapOf(
+                        "orderNumber" to "0123456789",
+                        "result" to Status.NEGATIVE,
+                        "type" to "94500-6"
+                    )
+                )
+            }.andExpect {
+                status { isOk }
+            }
+        }
     }
 
     @Nested
@@ -126,7 +146,7 @@ class LabControllerTest {
             every { updateResultUseCase(any(), any()) } returns
                     UpdateStatusResponse.Success
             every { extractObxResultUseCase(any(), any()) } returns
-                    LabResult(OrderNumber.External.random(), labIdHeader, Result.NEGATIVE)
+                    LabResult(OrderNumber.External.random(), labIdHeader, Result.NEGATIVE, null)
 
             mockMvc.put("/v1/results/obx") {
                 header(HttpHeaders.AUTHORIZATION, labIdHeader)

--- a/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
@@ -26,7 +26,7 @@ class UpdateResultUseCaseTest {
         notificationId = "notificationId"
     )
 
-    private val labResult = LabResult(orderNumber, "labId", Result.POSITIVE)
+    private val labResult = LabResult(orderNumber, "labId", Result.POSITIVE, null)
 
     @Test
     fun `returns Success result`() {


### PR DESCRIPTION
Add an optional `type` field to the JSON input (and a placeholder for OBX input) that specifies the clinical test used to determine the result.  It is persisted, but not used yet

Fixes #40 