### PR TITLE
Run tests in build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
     image: openjdk:11-jdk-slim
     <<: *gradle_user_home
     commands:
-      - ./gradlew --no-daemon bootJar
+      - ./gradlew --no-daemon build
 
   - name: gradle dependency check
     image: openjdk:11-jdk-slim


### PR DESCRIPTION
`bootJar` does not run tests by default, but `build` does