### PR TITLE
Allow cross origin requests on the orders resources

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/CorsConfig.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/CorsConfig.kt
@@ -1,0 +1,18 @@
+package com.healthmetrix.labres
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class CorsConfig(
+    @Value("\${cors-domains}")
+    private val allowedDomains: List<String>
+) : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/v1/orders/**")
+            .allowedMethods("PUT", "GET", "POST")
+            .allowedOrigins(*allowedDomains.toTypedArray())
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,9 @@ notification:
     user: # empty
     pass: # empty
 
+# has to be a comma separated string
+cors-domains: "*"
+
 ---
 spring:
   profiles: dev


### PR DESCRIPTION
Configurable with a comma separated list in the application.yaml

Fixes #53 