### PR TITLE
Include profile 'notify' on profile 'dev'

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,6 @@ notification:
 ---
 spring:
   profiles: dev
-  profiles.include: dynamo
+  profiles.include: dynamo, notify
 
 dynamo.local-endpoint:


### PR DESCRIPTION
As it is obvious that we always want to use actual notifications when deploying to our `dev` stage, I included the `notify` profile already to the `dev` profile instead of setting both profiles on the deployment.