### PR TITLE
Feature/metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ notification to the registered token.
 
 - `jsonlog`: When enabled, outputs log messages in json format
 
-- `dev`: Sets sane defaults for a dev environment next to including the profiles `dynamo`, `notify`, `secrets` and `jsonlog`
+- `cloudwatch`: When enabled, uploads metrics to cloudwatch instead of collecting them in memory.
 
-- `prod`: Sets sane defaults for a dev environment next to including the profiles `dynamo`, `notify`, `secrets` and `jsonlog`
+- `dev`: Sets sane defaults for a dev environment next to including the profiles `dynamo`, `notify`, `secrets`, `jsonlog` and `cloudwatch`
+
+- `prod`: Sets sane defaults for a dev environment next to including the profiles `dynamo`, `notify`, `secrets`, `jsonlog` and `cloudwatch`
 
   
 ## License

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     // structured logging
     implementation("net.logstash.logback:logstash-logback-encoder:6.4")
 
+    // metrics
+    implementation("io.micrometer:micrometer-registry-cloudwatch2:1.5.1")
+
     // serialization
     val jacksonVersion = "2.11.0"
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")

--- a/src/main/kotlin/com/healthmetrix/labres/MicrometerCloudwatchConfig.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/MicrometerCloudwatchConfig.kt
@@ -1,0 +1,39 @@
+package com.healthmetrix.labres
+
+import io.micrometer.cloudwatch2.CloudWatchConfig
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry
+import io.micrometer.core.instrument.Clock
+import io.micrometer.core.instrument.Metrics
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import java.time.Duration
+
+@Configuration
+@Profile("cloudwatch")
+class MicrometerCloudwatchConfig {
+
+    @Bean
+    fun provideConfig(
+        @Value("\${labres.stage}")
+        stage: String,
+        @Value("\${metrics.cloudwatch.stepInSeconds}")
+        stepInSeconds: Long
+    ) = object : CloudWatchConfig {
+        private val configuration = mapOf(
+            "cloudwatch.namespace" to "lab-res/$stage",
+            "cloudwatch.step" to Duration.ofSeconds(stepInSeconds).toString()
+        )
+
+        override fun get(key: String) = configuration[key]
+    }
+
+    @Bean
+    fun provideRegistry(config: CloudWatchConfig) = CloudWatchMeterRegistry(
+        config,
+        Clock.SYSTEM,
+        CloudWatchAsyncClient.create()
+    ).also(Metrics::addRegistry)
+}

--- a/src/main/kotlin/com/healthmetrix/labres/lab/LabMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/LabMetrics.kt
@@ -12,7 +12,7 @@ class LabMetrics(
 ) {
 
     fun countPersistedTestResults(testResult: Result, labId: String, issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.labs.$labId.testResults.persisted.$testResult.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.labs.$labId.testResults.persisted.$testResult")
         .description("Increments the sum of $testResult testResults for issuer $issuerId and $labId")
         .tags(
             listOf(
@@ -28,7 +28,7 @@ class LabMetrics(
         .increment()
 
     fun countUpdateResults(updateResult: UpdateResult, labId: String, issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.labs.$labId.updateResults.$updateResult.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.labs.$labId.updateResults.$updateResult")
         .description("Increments the sum of $updateResult updateResults for issuer $issuerId and $labId")
         .tags(
             listOf(
@@ -44,7 +44,7 @@ class LabMetrics(
         .increment()
 
     fun countUnauthorized() = Counter
-        .builder("labApi.unauthorized.count")
+        .builder("labApi.unauthorized")
         .description("Increments the sum of unauthorized requests on the lab facing API")
         .tags(
             listOf(

--- a/src/main/kotlin/com/healthmetrix/labres/lab/LabMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/LabMetrics.kt
@@ -1,0 +1,59 @@
+package com.healthmetrix.labres.lab
+
+import com.healthmetrix.labres.order.EON_ISSUER_ID
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import org.springframework.stereotype.Component
+
+@Component
+class LabMetrics(
+    private val meterRegistry: MeterRegistry
+) {
+
+    fun countPersistedTestResults(testResult: Result, labId: String, issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.labs.$labId.testResults.persisted.$testResult.count")
+        .description("Increments the sum of $testResult testResults for issuer $issuerId and $labId")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "testResult"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID),
+                Tag.of("labId", labId)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countUpdateResults(updateResult: UpdateResult, labId: String, issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.labs.$labId.updateResults.$updateResult.count")
+        .description("Increments the sum of $updateResult updateResults for issuer $issuerId and $labId")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "updateResult"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID),
+                Tag.of("labId", labId)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countUnauthorized() = Counter
+        .builder("labApi.unauthorized.count")
+        .description("Increments the sum of unauthorized requests on the lab facing API")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "unauthorized")
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+}

--- a/src/main/kotlin/com/healthmetrix/labres/order/OrderMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/OrderMetrics.kt
@@ -1,0 +1,100 @@
+package com.healthmetrix.labres.order
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import org.springframework.stereotype.Component
+
+@Component
+class OrderMetrics(private val meterRegistry: MeterRegistry) {
+
+    fun countRegisteredOrders(issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.registered.count")
+        .description("Increments the sum of registered preissued order for issuer $issuerId")
+        .tags(
+            listOf(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "registerOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countConflictOnRegisteringOrders(issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.conflict.count")
+        .description("Increments the sum of conflicts on registering preissued order for issuer $issuerId")
+        .tags(
+            listOf(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "registerOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countErrorOnParsingOrderNumbersOnGet(issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNumberParseErrors.count")
+        .description("Increments the sum of errors parsing an order number for issuer $issuerId when getting an order")
+        .tags(
+            listOf(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "getOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countOrderNotFoundOnGet(issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNotFound.count")
+        .description("Increments the sum of orderNotFound for issuer $issuerId when getting an order")
+        .tags(
+            listOf(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "getOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countErrorOnParsingOrderNumbersOnUpdate(issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNumberParseErrors.count")
+        .description("Increments the sum of errors parsing an order number for issuer $issuerId when updating an order")
+        .tags(
+            listOf(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "updateOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countOrderNotFoundOnUpdate(issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNotFound.count")
+        .description("Increments the sum of orderNotFound for issuer $issuerId when updating an order")
+        .tags(
+            listOf(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "updateOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+}

--- a/src/main/kotlin/com/healthmetrix/labres/order/OrderMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/OrderMetrics.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 class OrderMetrics(private val meterRegistry: MeterRegistry) {
 
     fun countRegisteredOrders(issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.registered.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.registered")
         .description("Increments the sum of registered preissued order for issuer $issuerId")
         .tags(
             listOf(
@@ -24,7 +24,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .increment()
 
     fun countConflictOnRegisteringOrders(issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.conflict.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.conflict")
         .description("Increments the sum of conflicts on registering preissued order for issuer $issuerId")
         .tags(
             listOf(
@@ -39,7 +39,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .increment()
 
     fun countErrorOnParsingOrderNumbersOnGet(issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNumberParseErrors.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNumberParseErrors")
         .description("Increments the sum of errors parsing an order number for issuer $issuerId when getting an order")
         .tags(
             listOf(
@@ -54,7 +54,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .increment()
 
     fun countOrderNotFoundOnGet(issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNotFound.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNotFound")
         .description("Increments the sum of orderNotFound for issuer $issuerId when getting an order")
         .tags(
             listOf(
@@ -69,7 +69,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .increment()
 
     fun countErrorOnParsingOrderNumbersOnUpdate(issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNumberParseErrors.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNumberParseErrors")
         .description("Increments the sum of errors parsing an order number for issuer $issuerId when updating an order")
         .tags(
             listOf(
@@ -84,7 +84,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .increment()
 
     fun countOrderNotFoundOnUpdate(issuerId: String?): Unit = Counter
-        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNotFound.count")
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNotFound")
         .description("Increments the sum of orderNotFound for issuer $issuerId when updating an order")
         .tags(
             listOf(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,6 +74,8 @@ labres:
         issuers: labres
       - id: kevb
         issuers: kevb
+      - id: hmx
+        issuers: hmx
 
 spring:
   profiles: prod

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,6 +28,16 @@ documentation-info:
     url: https://www.labres.de
     email: admin@healthmetrix.com
 
+management:
+  metrics:
+    use-global-registry: false # to prevent spring from adding cloudwatch when starting locally
+    export.simple.enabled: true
+  endpoints:
+    web.exposure.include: health,info,beans,conditions,env,metrics
+    health:
+      show-details: always
+      show-components: always
+
 notification:
   basic-auth:
     user: # empty
@@ -40,6 +50,18 @@ cors-domains: "*"
 spring:
   profiles: jsonlog
   main.banner-mode: off
+
+---
+spring:
+  profiles: cloudwatch
+
+management:
+  metrics:
+    export.simple.enabled: false
+
+metrics:
+  cloudwatch:
+    stepInSeconds: 1
 
 ---
 labres:
@@ -55,7 +77,7 @@ labres:
 
 spring:
   profiles: dev
-  profiles.include: dynamo, notify, secrets, jsonlog
+  profiles.include: dynamo, notify, secrets, jsonlog, cloudwatch
 
 dynamo.local-endpoint:
 
@@ -64,6 +86,11 @@ documentation-info:
     - url: https://api.dev.labres.de
       description: dev environment for LabRes
       version: v1
+
+management:
+  endpoints:
+    web.exposure:
+      include: info,health
 
 ---
 labres:
@@ -88,3 +115,8 @@ documentation-info:
     - url: https://api.labres.de
       description: production environment for LabRes
       version: v1
+
+management:
+  endpoints:
+    web.exposure:
+      include: info,health

--- a/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
@@ -25,8 +25,9 @@ class LabControllerTest {
     private val updateResultUseCase: UpdateResultUseCase = mockk()
     private val bulkUpdateResultsUseCase: BulkUpdateResultsUseCase = mockk()
     private val labRegistry: LabRegistry = mockk()
+    private val metrics: LabMetrics = mockk(relaxUnitFun = true)
 
-    private val underTest = LabController(updateResultUseCase, bulkUpdateResultsUseCase, labRegistry)
+    private val underTest = LabController(updateResultUseCase, bulkUpdateResultsUseCase, labRegistry, metrics)
 
     private val objectMapper = ObjectMapper().registerKotlinModule()
     private val jsonMessageConverter = MappingJackson2HttpMessageConverter(objectMapper)

--- a/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
@@ -21,8 +21,10 @@ class PreIssuedOrderNumberControllerTest {
     private val registerOrderUseCase: RegisterOrderUseCase = mockk()
     private val updateOrderUseCase: UpdateOrderUseCase = mockk()
     private val queryStatusUseCase: QueryStatusUseCase = mockk()
+    private val metrics: OrderMetrics = mockk(relaxUnitFun = true)
 
-    private val underTest = PreIssuedOrderNumberController(registerOrderUseCase, updateOrderUseCase, queryStatusUseCase)
+    private val underTest =
+        PreIssuedOrderNumberController(registerOrderUseCase, updateOrderUseCase, queryStatusUseCase, metrics)
     private val mockMvc = MockMvcBuilders.standaloneSetup(underTest).build()
 
     private val objectMapper = ObjectMapper().registerKotlinModule()


### PR DESCRIPTION
Add micrometer with cloudwatch registry to upload default actuator exposed as well as first custom created metrics to cloudwatch (see https://eu-central-1.console.aws.amazon.com/cloudwatch/home?region=eu-central-1#metricsV2:graph=~();namespace=~'lab-res*2fdev for metrics on dev and https://eu-central-1.console.aws.amazon.com/cloudwatch/home?region=eu-central-1#dashboards:name=results;start=PT12H).

If profile `cloudwatch` is not set, metrics are only collected in memory and exposed via `actuator/metrics`