### PR TITLE
Add server side workaround for iOS bug swapping issuerId and testSiteId for mvz

### DIFF
--- a/src/test/kotlin/com/healthmetrix/labres/integration/IosBugWorkaroundTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/integration/IosBugWorkaroundTest.kt
@@ -1,0 +1,98 @@
+package com.healthmetrix.labres.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.healthmetrix.labres.LabResApplication
+import com.healthmetrix.labres.order.PreIssuedOrderNumberController
+import com.healthmetrix.labres.order.Sample
+import com.healthmetrix.labres.order.Status
+import com.healthmetrix.labres.persistence.InMemoryOrderInformationRepository
+import com.healthmetrix.labres.persistence.OrderInformationRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+@SpringBootTest(
+    classes = [LabResApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@AutoConfigureMockMvc
+class IosBugWorkaroundTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var repository: OrderInformationRepository
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    internal fun setUp() {
+        (repository as InMemoryOrderInformationRepository).clear()
+    }
+
+    private val orderNumber = "1234567890"
+
+    @Test
+    fun `should set issuerId to mvz if incoming issuerId is hpi`() {
+        val incomingIssuerId = "hpi"
+        val incomingTestSiteId = "something"
+        val registeredResponse = registerOrder(incomingIssuerId, incomingTestSiteId)
+
+        val result = repository.findById(registeredResponse.id)
+
+        assertThat(result).isNotNull
+        assertThat(result!!).matches {
+            it.status == Status.IN_PROGRESS &&
+                it.orderNumber.issuerId == "mvz" &&
+                it.sample == Sample.SALIVA &&
+                it.testSiteId == incomingIssuerId
+        }
+    }
+
+    @Test
+    fun `should set issuerId to mvz if incoming issuerId is wmt`() {
+        val incomingIssuerId = "wmt"
+        val incomingTestSiteId = "something"
+        val registeredResponse = registerOrder(incomingIssuerId, incomingTestSiteId)
+
+        val result = repository.findById(registeredResponse.id)
+
+        assertThat(result).isNotNull
+        assertThat(result!!).matches {
+            it.status == Status.IN_PROGRESS &&
+                it.orderNumber.issuerId == "mvz" &&
+                it.sample == Sample.SALIVA &&
+                it.testSiteId == incomingIssuerId
+        }
+    }
+
+    private fun registerOrder(
+        issuerId: String,
+        testSiteId: String
+    ): PreIssuedOrderNumberController.RegisterOrderResponse.Created {
+        return mockMvc.post("/v1/issuers/$issuerId/orders") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsBytes(
+                mapOf(
+                    "orderNumber" to orderNumber,
+                    "sample" to Sample.SALIVA,
+                    "testSiteId" to testSiteId
+                )
+            )
+        }.andReturn().responseBody()
+    }
+
+    private inline fun <reified T> MvcResult.responseBody(): T {
+        return objectMapper.readValue(response.contentAsString)
+    }
+}


### PR DESCRIPTION
The LabRes apps take issuerId and testSite from a check in QR code.
The android app takes the first three chars of the encoded value as the issuerId and the next three as testSiteId. The iOS app on the other hand turns these values around. Until we have this fixed, there should be a workaround on server side that swaps these two values if issuerId is either "hpi" or "wmt", which are the only to cases where we have issuerId and testSiteId not set to the same value yet.