### PR TITLE
Improve metrics and tidy up logs

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/notifications/FirebaseNotifier.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/notifications/FirebaseNotifier.kt
@@ -6,7 +6,11 @@ import com.google.firebase.messaging.FirebaseMessagingException
 import com.google.firebase.messaging.Message
 import com.healthmetrix.labres.logger
 
-class FirebaseNotifier(private val messaging: FirebaseMessaging, private val dryRun: Boolean = true) :
+class FirebaseNotifier(
+    private val messaging: FirebaseMessaging,
+    private val dryRun: Boolean = true,
+    private val metrics: NotificationMetrics
+) :
     Notifier<Notification.FcmNotification> {
     override fun send(notification: Notification.FcmNotification): Boolean {
         val message = Message.builder()
@@ -31,6 +35,7 @@ class FirebaseNotifier(private val messaging: FirebaseMessaging, private val dry
             messageId != null
         } catch (ex: FirebaseMessagingException) {
             logger.warn("Failed sending message to FCM", ex)
+            metrics.countFcmNotificationFailed()
             false
         }
     }

--- a/src/main/kotlin/com/healthmetrix/labres/notifications/HttpNotifier.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/notifications/HttpNotifier.kt
@@ -3,7 +3,10 @@ package com.healthmetrix.labres.notifications
 import com.healthmetrix.labres.logger
 import org.springframework.web.reactive.function.client.WebClient
 
-class HttpNotifier(private val configHttp: HttpNotificationConfig) : Notifier<Notification.HttpNotification> {
+class HttpNotifier(
+    private val configHttp: HttpNotificationConfig,
+    private val metrics: NotificationMetrics
+) : Notifier<Notification.HttpNotification> {
 
     override fun send(notification: Notification.HttpNotification) = try {
         val response = WebClient.create(notification.url)
@@ -20,6 +23,7 @@ class HttpNotifier(private val configHttp: HttpNotificationConfig) : Notifier<No
         response?.statusCode?.is2xxSuccessful ?: false
     } catch (ex: Exception) {
         logger.warn("Failed to notify", ex)
+        metrics.countHttpNotificationFailed()
         false
     }
 }

--- a/src/main/kotlin/com/healthmetrix/labres/notifications/NotificationMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/notifications/NotificationMetrics.kt
@@ -1,0 +1,56 @@
+package com.healthmetrix.labres.notifications
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+
+class NotificationMetrics(private val meterRegistry: MeterRegistry) {
+
+    fun countTargetEmpty() = Counter.builder("notifications.target.empty")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "notifications")
+            )
+        )
+        .register(meterRegistry)
+        .increment()
+
+    fun countTargetNotSupported() = Counter.builder("notifications.target.not_supported")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "notifications")
+            )
+        )
+        .register(meterRegistry)
+        .increment()
+
+    fun countFcmNotificationFailed() = Counter.builder("notifications.target.fcm.failed")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "notifications")
+            )
+        )
+        .register(meterRegistry)
+        .increment()
+
+    fun countHttpNotificationFailed() = Counter.builder("notifications.target.http.failed")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "notifications")
+            )
+        )
+        .register(meterRegistry)
+        .increment()
+}

--- a/src/main/kotlin/com/healthmetrix/labres/notifications/NotificationMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/notifications/NotificationMetrics.kt
@@ -3,7 +3,9 @@ package com.healthmetrix.labres.notifications
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
+import org.springframework.stereotype.Component
 
+@Component
 class NotificationMetrics(private val meterRegistry: MeterRegistry) {
 
     fun countTargetEmpty() = Counter.builder("notifications.target.empty")

--- a/src/main/kotlin/com/healthmetrix/labres/notifications/NotifyOnStatusChangeUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/notifications/NotifyOnStatusChangeUseCase.kt
@@ -7,14 +7,15 @@ import java.util.UUID
 @Service
 class NotifyOnStatusChangeUseCase(
     private val fcmNotifier: Notifier<Notification.FcmNotification>,
-    private val httpNotifier: Notifier<Notification.HttpNotification>
+    private val httpNotifier: Notifier<Notification.HttpNotification>,
+    private val metrics: NotificationMetrics
 ) {
     operator fun invoke(orderId: UUID, targets: List<String>): Boolean {
         if (targets.isEmpty()) {
             logger.warn("No notification url for $orderId")
             return false
         }
-
+        metrics.countTargetEmpty()
         logger.debug("Sending notification for id $orderId to $targets")
 
         return targets
@@ -28,6 +29,7 @@ class NotifyOnStatusChangeUseCase(
             is Notification.FcmNotification -> fcmNotifier.send(notification)
             null -> {
                 logger.warn("Notification type for id $orderId not supported: $target")
+                metrics.countTargetNotSupported()
                 false
             }
         }

--- a/src/main/kotlin/com/healthmetrix/labres/order/OrderMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/OrderMetrics.kt
@@ -8,31 +8,49 @@ import org.springframework.stereotype.Component
 @Component
 class OrderMetrics(private val meterRegistry: MeterRegistry) {
 
-    fun countRegisteredOrders(issuerId: String?): Unit = Counter
+    fun countRegisteredOrders(issuerId: String?, testSiteId: String?): Unit = Counter
         .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.registered")
         .description("Increments the sum of registered preissued order for issuer $issuerId")
         .tags(
-            listOf(
+            listOfNotNull(
                 Tag.of("api", "orders"),
                 Tag.of("operation", "registerOrder"),
                 Tag.of("metric", "count"),
                 Tag.of("scope", "orders"),
-                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID),
+                testSiteId?.let { Tag.of("testSiteId", it) }
             )
         )
         .register(meterRegistry) // idempotent
         .increment()
 
-    fun countConflictOnRegisteringOrders(issuerId: String?): Unit = Counter
+    fun countRegisteringOrdersMultipleTimes(issuerId: String?, testSiteId: String?): Unit = Counter
         .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.conflict")
-        .description("Increments the sum of conflicts on registering preissued order for issuer $issuerId")
+        .description("Increments the sum of conflicts on registering an order for issuer $issuerId")
         .tags(
-            listOf(
+            listOfNotNull(
                 Tag.of("api", "orders"),
                 Tag.of("operation", "registerOrder"),
                 Tag.of("metric", "count"),
                 Tag.of("scope", "orders"),
-                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID),
+                testSiteId?.let { Tag.of("testSiteId", it) }
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countConflictOnRegisteringOrders(issuerId: String?, testSiteId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.registration.conflict")
+        .description("Increments the sum of conflicts on registering an order for issuer $issuerId")
+        .tags(
+            listOfNotNull(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "registerOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID),
+                testSiteId?.let { Tag.of("testSiteId", it) }
             )
         )
         .register(meterRegistry) // idempotent
@@ -42,7 +60,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNumberParseErrors")
         .description("Increments the sum of errors parsing an order number for issuer $issuerId when getting an order")
         .tags(
-            listOf(
+            listOfNotNull(
                 Tag.of("api", "orders"),
                 Tag.of("operation", "getOrder"),
                 Tag.of("metric", "count"),
@@ -57,7 +75,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.get.orderNotFound")
         .description("Increments the sum of orderNotFound for issuer $issuerId when getting an order")
         .tags(
-            listOf(
+            listOfNotNull(
                 Tag.of("api", "orders"),
                 Tag.of("operation", "getOrder"),
                 Tag.of("metric", "count"),
@@ -72,7 +90,7 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNumberParseErrors")
         .description("Increments the sum of errors parsing an order number for issuer $issuerId when updating an order")
         .tags(
-            listOf(
+            listOfNotNull(
                 Tag.of("api", "orders"),
                 Tag.of("operation", "updateOrder"),
                 Tag.of("metric", "count"),
@@ -87,12 +105,41 @@ class OrderMetrics(private val meterRegistry: MeterRegistry) {
         .builder("issuers.${issuerId ?: EON_ISSUER_ID}.orders.update.orderNotFound")
         .description("Increments the sum of orderNotFound for issuer $issuerId when updating an order")
         .tags(
-            listOf(
+            listOfNotNull(
                 Tag.of("api", "orders"),
                 Tag.of("operation", "updateOrder"),
                 Tag.of("metric", "count"),
                 Tag.of("scope", "orders"),
                 Tag.of("issuerId", issuerId ?: EON_ISSUER_ID)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countRewriteIssuerIdForIosBug(): Unit = Counter
+        .builder("issuers.mvz.orders.iosbug.rewrite")
+        .description("Counts how many times issuerId and testSiteId are being switched to tidy up the iOS bug")
+        .tags(
+            listOfNotNull(
+                Tag.of("api", "orders"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", "mvz")
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
+    fun countTruncateKevbSuffix(): Unit = Counter
+        .builder("issuers.kevb.orders.truncate_suffix")
+        .description("Counts how many times the analyt suffix is being truncated for kevb")
+        .tags(
+            listOfNotNull(
+                Tag.of("api", "orders"),
+                Tag.of("operation", "registerOrder"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "orders"),
+                Tag.of("issuerId", "mvz")
             )
         )
         .register(meterRegistry) // idempotent

--- a/src/main/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCase.kt
@@ -15,8 +15,8 @@ import java.util.UUID
 @Component
 class RegisterOrderUseCase(
     private val repository: OrderInformationRepository,
-    private val idGenerator: () -> UUID = UUID::randomUUID,
-    private val metrics: OrderMetrics
+    private val metrics: OrderMetrics,
+    private val idGenerator: () -> UUID = UUID::randomUUID
 ) {
     operator fun invoke(
         orderNumber: OrderNumber,

--- a/src/main/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCase.kt
@@ -15,7 +15,8 @@ import java.util.UUID
 @Component
 class RegisterOrderUseCase(
     private val repository: OrderInformationRepository,
-    private val idGenerator: () -> UUID = UUID::randomUUID
+    private val idGenerator: () -> UUID = UUID::randomUUID,
+    private val metrics: OrderMetrics
 ) {
     operator fun invoke(
         orderNumber: OrderNumber,
@@ -36,7 +37,8 @@ class RegisterOrderUseCase(
             ).let(repository::save).let(::Ok)
 
         if (!existing.notificationUrls.contains(notificationUrl)) {
-            logger.warn(
+            metrics.countRegisteringOrdersMultipleTimes(orderNumber.issuerId, testSiteId)
+            logger.debug(
                 "[{}] Order already exists with a different notificationUrl",
                 StructuredArguments.kv("method", "registerOrder"),
                 StructuredArguments.kv("issuerId", orderNumber.issuerId),

--- a/src/test/kotlin/com/healthmetrix/labres/notifications/NotifyOnStatusChangeUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/notifications/NotifyOnStatusChangeUseCaseTest.kt
@@ -14,8 +14,9 @@ internal class NotifyOnStatusChangeUseCaseTest {
 
     private val fcmNotifier: Notifier<Notification.FcmNotification> = mockk()
     private val httpNotifier: Notifier<Notification.HttpNotification> = mockk()
+    private val metrics: NotificationMetrics = mockk(relaxed = true)
 
-    private val underTest = NotifyOnStatusChangeUseCase(fcmNotifier, httpNotifier)
+    private val underTest = NotifyOnStatusChangeUseCase(fcmNotifier, httpNotifier, metrics)
 
     @BeforeEach
     internal fun setUp() {

--- a/src/test/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCaseTest.kt
@@ -27,8 +27,9 @@ internal class RegisterOrderUseCaseTest {
     private val now = Instant.now()
 
     private val repository: OrderInformationRepository = mockk()
+    private val metrics: OrderMetrics = mockk(relaxed = true)
 
-    private val underTest = RegisterOrderUseCase(repository) { orderId }
+    private val underTest = RegisterOrderUseCase(repository, metrics) { orderId }
 
     @BeforeEach
     internal fun setUp() {


### PR DESCRIPTION
Based on the dashboards and logs of prod over the last days I tidied up some of the logging and added metrics therefore
- IOS bug rewrite shouldn't spam the logs --> switched to metric
- truncating kevb order numbers shouldn't spam the logs --> switched to metric
- Add testSiteId as tag to registerOrder metrics
- Registering an order that already existing but had only < 3 notificationUrls and no result yet shouldn't spam the logs --> switched to metric
- Added metrics for notifications