### PR TITLE
Deal with dynamoDB's eventual consistency by always handling a list of orders on querying by order number

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/notifications/NotifyOnStatusChangeUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/notifications/NotifyOnStatusChangeUseCase.kt
@@ -13,12 +13,13 @@ class NotifyOnStatusChangeUseCase(
     operator fun invoke(orderId: UUID, targets: List<String>): Boolean {
         if (targets.isEmpty()) {
             logger.warn("No notification url for $orderId")
+            metrics.countTargetEmpty()
             return false
         }
-        metrics.countTargetEmpty()
         logger.debug("Sending notification for id $orderId to $targets")
 
         return targets
+            .distinct()
             .map { sendNotification(orderId, it) }
             .reduce(Boolean::and)
     }

--- a/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
@@ -57,7 +57,7 @@ class UpdateResultUseCaseTest {
 
     @Test
     fun `returns SUCCESS if successfully updated`() {
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns orderInfo
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(orderInfo)
         every { repository.save(any()) } returns updated
         every { notifier.invoke(any(), any()) } returns true
 
@@ -68,7 +68,7 @@ class UpdateResultUseCaseTest {
     fun `updates orderInformation with enteredLabAt set if status is IN_PROGRESS`() {
         clearMocks(repository)
 
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns orderInfo
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(orderInfo)
         val updated = updated.copy(status = Status.IN_PROGRESS, enteredLabAt = now)
         every { repository.save(any()) } returns updated
         every { notifier.invoke(any(), any()) } returns true
@@ -82,7 +82,7 @@ class UpdateResultUseCaseTest {
     fun `notifies on updated order`() {
         clearMocks(notifier)
 
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns orderInfo
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(orderInfo)
         every { repository.save(any()) } returns updated
         every { notifier.invoke(any(), any()) } returns true
 
@@ -93,14 +93,14 @@ class UpdateResultUseCaseTest {
 
     @Test
     fun `returns ORDER_NOT_FOUND if no orderNumber found`() {
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns null
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns emptyList()
         assertThat(underTest(updateResultRequest, labId, issuerId)).isEqualTo(UpdateResult.ORDER_NOT_FOUND)
     }
 
     @Test
     fun `doesn't update or notify if no orderNumber found`() {
         clearMocks(repository)
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns null
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns emptyList()
 
         underTest(updateResultRequest, labId, issuerId)
 
@@ -114,7 +114,7 @@ class UpdateResultUseCaseTest {
     fun `updates orderInformation with reportedAt set if status is not IN_PROGRESS`() {
         clearMocks(repository)
 
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns orderInfo
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(orderInfo)
         val updated = updated.copy(reportedAt = now, testType = testType)
         every { repository.save(any()) } returns updated
         every { notifier.invoke(any(), any()) } returns true
@@ -126,7 +126,7 @@ class UpdateResultUseCaseTest {
 
     @Test
     fun `returns INVALID_ORDER_NUMBER if order number can't be parsed`() {
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns orderInfo
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(orderInfo)
         every { repository.save(any()) } returns updated
         every { notifier.invoke(any(), any()) } returns true
         every { OrderNumber.from(any(), any()) } throws IllegalArgumentException()

--- a/src/test/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCaseTest.kt
@@ -35,7 +35,7 @@ internal class RegisterOrderUseCaseTest {
     internal fun setUp() {
         clearMocks(repository)
         every { repository.save(any()) } answers { arg(0) }
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns null
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns emptyList()
     }
 
     @Test
@@ -76,13 +76,15 @@ internal class RegisterOrderUseCaseTest {
     fun `it should save orderInformation when there is an existing order with less than 3 notification urls`() {
         val existingNotificationUrls = listOf("a", "b")
 
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns OrderInformation(
-            id = orderId,
-            orderNumber = preIssuedOrderNumber,
-            status = Status.IN_PROGRESS,
-            issuedAt = Date.from(now),
-            sample = Sample.SALIVA,
-            notificationUrls = existingNotificationUrls
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(
+            OrderInformation(
+                id = orderId,
+                orderNumber = preIssuedOrderNumber,
+                status = Status.IN_PROGRESS,
+                issuedAt = Date.from(now),
+                sample = Sample.SALIVA,
+                notificationUrls = existingNotificationUrls
+            )
         )
 
         underTest.invoke(preIssuedOrderNumber, testSiteId, Sample.SALIVA, notificationUrl, now)
@@ -106,13 +108,15 @@ internal class RegisterOrderUseCaseTest {
     fun `it should save orderInformation when there is an existing order with 3 notification urls including the new notificationUrl`() {
         val existingNotificationUrls = listOf("a", "b", notificationUrl)
 
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns OrderInformation(
-            id = orderId,
-            orderNumber = preIssuedOrderNumber,
-            status = Status.IN_PROGRESS,
-            issuedAt = Date.from(now),
-            sample = Sample.SALIVA,
-            notificationUrls = existingNotificationUrls
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(
+            OrderInformation(
+                id = orderId,
+                orderNumber = preIssuedOrderNumber,
+                status = Status.IN_PROGRESS,
+                issuedAt = Date.from(now),
+                sample = Sample.SALIVA,
+                notificationUrls = existingNotificationUrls
+            )
         )
 
         underTest.invoke(preIssuedOrderNumber, testSiteId, Sample.SALIVA, notificationUrl, now)
@@ -134,13 +138,15 @@ internal class RegisterOrderUseCaseTest {
 
     @Test
     fun `it should return null if order has already been registered with more than 3 different notificationUrls`() {
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns OrderInformation(
-            id = orderId,
-            orderNumber = eon,
-            status = Status.IN_PROGRESS,
-            issuedAt = Date.from(now),
-            sample = Sample.SALIVA,
-            notificationUrls = listOf("a", "b", "c")
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(
+            OrderInformation(
+                id = orderId,
+                orderNumber = eon,
+                status = Status.IN_PROGRESS,
+                issuedAt = Date.from(now),
+                sample = Sample.SALIVA,
+                notificationUrls = listOf("a", "b", "c")
+            )
         )
 
         val res = underTest.invoke(preIssuedOrderNumber, testSiteId, Sample.SALIVA, notificationUrl, now)
@@ -150,13 +156,15 @@ internal class RegisterOrderUseCaseTest {
 
     @Test
     fun `it should return null if the order already has a status that is not IN_PROGRESS`() {
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns OrderInformation(
-            id = orderId,
-            orderNumber = eon,
-            status = Status.POSITIVE,
-            issuedAt = Date.from(now),
-            sample = Sample.SALIVA,
-            notificationUrls = listOf("a")
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(
+            OrderInformation(
+                id = orderId,
+                orderNumber = eon,
+                status = Status.POSITIVE,
+                issuedAt = Date.from(now),
+                sample = Sample.SALIVA,
+                notificationUrls = listOf("a")
+            )
         )
 
         val res = underTest.invoke(preIssuedOrderNumber, testSiteId, Sample.SALIVA, notificationUrl, now)
@@ -166,13 +174,15 @@ internal class RegisterOrderUseCaseTest {
 
     @Test
     fun `it should not save anything if the order has already been registered three times`() {
-        every { repository.findByOrderNumberAndSample(any(), any()) } returns OrderInformation(
-            id = orderId,
-            orderNumber = eon,
-            status = Status.IN_PROGRESS,
-            issuedAt = Date.from(now),
-            sample = Sample.SALIVA,
-            notificationUrls = listOf("a", "b", "c")
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(
+            OrderInformation(
+                id = orderId,
+                orderNumber = eon,
+                status = Status.IN_PROGRESS,
+                issuedAt = Date.from(now),
+                sample = Sample.SALIVA,
+                notificationUrls = listOf("a", "b", "c")
+            )
         )
 
         underTest.invoke(preIssuedOrderNumber, testSiteId, Sample.SALIVA, notificationUrl, now)

--- a/src/test/kotlin/com/healthmetrix/labres/persistence/DynamoOrderInformationRepositoryTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/persistence/DynamoOrderInformationRepositoryTest.kt
@@ -104,13 +104,13 @@ internal class DynamoOrderInformationRepositoryTest {
     }
 
     @Test
-    fun `findByOrderNumberAndSample should return null when there is no order with the according sample`() {
+    fun `findByOrderNumberAndSample should return an empty list when there is no order with the according sample`() {
         every { orderInformation.sample } returns Sample.BLOOD
         every { repository.findByIssuerIdAndOrderNumber(any(), any()) } returns listOf(rawOrderInformation)
 
         val result = underTest.findByOrderNumberAndSample(orderNumber, Sample.SALIVA)
 
-        assertThat(result).isNull()
+        assertThat(result).isEmpty()
     }
 
     @Test
@@ -120,11 +120,11 @@ internal class DynamoOrderInformationRepositoryTest {
 
         val result = underTest.findByOrderNumberAndSample(orderNumber, Sample.SALIVA)
 
-        assertThat(result).isEqualTo(orderInformation)
+        assertThat(result).isEqualTo(listOf(orderInformation))
     }
 
     @Test
-    fun `findByOrderNumberAndSample should return the newer order only even when there are two due to bad state`() {
+    fun `findByOrderNumberAndSample should return the multiple orders`() {
         every { orderInformation.sample } returns Sample.SALIVA
         every { orderInformation.issuedAt } returns Date.from(Instant.now().minusSeconds(60))
         every { secondOrderInformation.sample } returns Sample.SALIVA
@@ -136,7 +136,7 @@ internal class DynamoOrderInformationRepositoryTest {
 
         val result = underTest.findByOrderNumberAndSample(orderNumber, Sample.SALIVA)
 
-        assertThat(result).isEqualTo(secondOrderInformation)
+        assertThat(result).isEqualTo(listOf(orderInformation, secondOrderInformation))
     }
 
     @Test


### PR DESCRIPTION
Dynamo DB supports only eventual read consistency on querying global secondary indeces. As we've implemented the identifier orderNumber + issuerId as global secondary index, we've run in the following behavior on production:
- user clicks twice on register order button in android app
- app sends two registerOrder requests with issuerId, orderNumber and sample type in a time window < 15ms
- the first request finds no existing order and creates the item in the database
- the second request should find the existing entry but doesn't due to eventual consistency
- this leads to duplicate entries in the DB as uniqueness can't be enforced on secondary indeces in dynamoDB

On uploading a result, so far only the newest entry based on the issuedAt timestamp was being updated. This is correct under the assumption that the app persists the returned Id of the second of both registerOrder requests, which I don't know.
To be on the safe side, we decided to always update all entries in the database with a result for a given orderNumber, issuerId and sample type even though only due the bad eventual consistency behavior there can actually exist more than one entry.