### PR TITLE
Add optional parameter for specifying sample types to issue EON endpoint

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberController.kt
@@ -94,9 +94,9 @@ class ExternalOrderNumberController(
     )
     fun issueExternalOrderNumber(
         @RequestBody(required = false)
-        requestBody: IssueExternalOrderNumberRequestBody?
+        requestBody: IssueExternalOrderNumberRequestBody? // nullable for backwards compatibility
     ): ResponseEntity<IssueExternalOrderNumberResponse> {
-        val order = issueExternalOrderNumber(requestBody?.notificationUrl)
+        val order = issueExternalOrderNumber(requestBody?.notificationUrl, requestBody?.sample ?: Sample.SALIVA)
             ?: return IssueExternalOrderNumberResponse.Conflict.asEntity()
 
         return IssueExternalOrderNumberResponse.Created(order.id, order.orderNumber.number).asEntity()
@@ -226,7 +226,16 @@ class ExternalOrderNumberController(
             example = "https://client.labres.de/notification",
             required = true
         )
-        val notificationUrl: String
+        val notificationUrl: String?,
+
+        @Schema(
+            description = "The sample type that is being used for the lab test.",
+            nullable = true,
+            required = false,
+            defaultValue = "SALIVA",
+            example = "BLOOD"
+        )
+        val sample: Sample = Sample.SALIVA
     )
 
     sealed class IssueExternalOrderNumberResponse(httpStatus: HttpStatus, hasBody: Boolean = true) :

--- a/src/main/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCase.kt
@@ -12,13 +12,13 @@ class IssueExternalOrderNumberUseCase(
     private val repository: OrderInformationRepository,
     private val registerOrder: RegisterOrderUseCase
 ) {
-    operator fun invoke(notificationUrl: String?): OrderInformation? {
+    operator fun invoke(notificationUrl: String?, sample: Sample): OrderInformation? {
         val eon = issueNewEon()
         return registerOrder(
             eon,
             testSiteId = null,
             notificationUrl = notificationUrl,
-            sample = Sample.SALIVA
+            sample = sample
         ).getOr { null }
     }
 

--- a/src/test/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberControllerTest.kt
@@ -39,14 +39,13 @@ class ExternalOrderNumberControllerTest {
     )
 
     @Nested
-    inner class CreateOrderEndpointTest {
+    inner class CreateOrderEndpointWithoutNotificationUrlTest {
         @Test
         fun `issuing an external order number returns status 201`() {
-            every { issueExternalOrderNumberUseCase.invoke(any()) } returns order
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
 
             mockMvc.post("/v1/orders") {
                 contentType = MediaType.APPLICATION_JSON
-                content = "{\"notificationUrl\":\"http://test.test\"}"
             }.andExpect {
                 status { isCreated }
             }
@@ -54,10 +53,106 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `issuing an external order number returns order number and id`() {
-            every { issueExternalOrderNumberUseCase.invoke(any()) } returns order
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
 
             mockMvc.post("/v1/orders") {
                 contentType = MediaType.APPLICATION_JSON
+            }.andExpect {
+                jsonPath("$.orderNumber") { isString }
+                jsonPath("$.id") { isString }
+            }
+        }
+    }
+
+    @Nested
+    inner class CreateOrderEndpointWithNotificationUrlTest {
+        @Test
+        fun `issuing an external order number returns status 201`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = "http://test.test")
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated }
+            }
+        }
+
+        @Test
+        fun `issuing an external order number returns order number and id`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = "http://test.test")
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                jsonPath("$.orderNumber") { isString }
+                jsonPath("$.id") { isString }
+            }
+        }
+    }
+
+    @Nested
+    inner class CreateOrderEndpointWithSalivaTest {
+        @Test
+        fun `issuing an external order number returns status 201`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.SALIVA)
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated }
+            }
+        }
+
+        @Test
+        fun `issuing an external order number returns order number and id`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.SALIVA)
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                jsonPath("$.orderNumber") { isString }
+                jsonPath("$.id") { isString }
+            }
+        }
+    }
+
+    @Nested
+    inner class CreateOrderEndpointWithBloodTest {
+        @Test
+        fun `issuing an external order number returns status 201`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.BLOOD)
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated }
+            }
+        }
+
+        @Test
+        fun `issuing an external order number returns order number and id`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns order
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.BLOOD)
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
             }.andExpect {
                 jsonPath("$.orderNumber") { isString }
                 jsonPath("$.id") { isString }

--- a/src/test/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCaseTest.kt
@@ -35,7 +35,7 @@ internal class IssueExternalOrderNumberUseCaseTest {
         every { repository.findByOrderNumber(any()) } returns emptyList()
         every { registerOrder(any(), any(), any(), any(), any()) } returns Ok(order)
 
-        assertThat(underTest(notificationUrl)).isEqualTo(order)
+        assertThat(underTest(notificationUrl, Sample.SALIVA)).isEqualTo(order)
     }
 
     @Test
@@ -47,7 +47,7 @@ internal class IssueExternalOrderNumberUseCaseTest {
         )
         every { registerOrder(any(), any(), any(), any(), any()) } returns Ok(order)
 
-        underTest(notificationUrl)
+        underTest(notificationUrl, Sample.SALIVA)
 
         verify { registerOrder(any(), null, any(), notificationUrl, any()) }
     }
@@ -57,7 +57,7 @@ internal class IssueExternalOrderNumberUseCaseTest {
         every { repository.findByOrderNumber(any()) } returns emptyList()
         every { registerOrder(any(), any(), any(), any(), any()) } returns Ok(order)
 
-        underTest(notificationUrl)
+        underTest(notificationUrl, Sample.SALIVA)
 
         verify {
             registerOrder(


### PR DESCRIPTION
D4L finally asked also for being able to issue LabRes orders for both sample types saliva and blood.
Therefore I added the optional parameter also to the EON API