### PR TITLE
Add sampledAt timestamp to OrderInformation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,9 @@ type: docker
 .release: &release
   image: amazon/aws-cli
   commands:
+    - aws sts get-caller-identity
     - cp -r .aws $HOME/.aws
+    - aws sts get-caller-identity
     - aws s3 cp build/libs/lab-res.jar s3://$${BUCKET_NAME}/${DRONE_COMMIT_SHA:0:8}/${DRONE_BUILD_NUMBER}/lab-res.jar
     - >
       aws elasticbeanstalk create-application-version

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,9 +26,7 @@ type: docker
 .release: &release
   image: amazon/aws-cli
   commands:
-    - aws sts get-caller-identity
     - cp -r .aws $HOME/.aws
-    - aws sts get-caller-identity
     - aws s3 cp build/libs/lab-res.jar s3://$${BUCKET_NAME}/${DRONE_COMMIT_SHA:0:8}/${DRONE_BUILD_NUMBER}/lab-res.jar
     - >
       aws elasticbeanstalk create-application-version

--- a/src/main/kotlin/com/healthmetrix/labres/lab/LabController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/LabController.kt
@@ -309,8 +309,10 @@ data class UpdateResultRequest(
         example = "1234567890"
     )
     val orderNumber: String,
+
     @Schema(description = "The test result")
     val result: Result,
+
     @Schema(
         description = "The kind of test used to generate the given result.",
         nullable = true,
@@ -319,7 +321,15 @@ data class UpdateResultRequest(
         allowableValues = [PCR_LOINC],
         example = "NGS"
     )
-    val type: TestType = TestType.PCR
+    val type: TestType = TestType.PCR,
+
+    @Schema(
+        description = "Unix Epoch timestamp when the sample has been taken",
+        nullable = true,
+        required = false,
+        example = "1596184744"
+    )
+    val sampledAt: Long? = null
 )
 
 sealed class UpdateResultResponse(

--- a/src/main/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCase.kt
@@ -47,7 +47,8 @@ class UpdateResultUseCase(
     ) = existing.copy(
         status = updateResultRequest.result.asStatus(),
         labId = labId,
-        testType = updateResultRequest.type
+        testType = updateResultRequest.type,
+        sampledAt = updateResultRequest.sampledAt
     )
 
     private fun updateTimestamp(orderInformation: OrderInformation, result: Result, now: Date) =

--- a/src/main/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberController.kt
@@ -65,7 +65,7 @@ import java.util.UUID
 class ExternalOrderNumberController(
     private val issueExternalOrderNumber: IssueExternalOrderNumberUseCase,
     private val updateOrderUseCase: UpdateOrderUseCase,
-    private val queryStatusUseCase: QueryStatusUseCase
+    private val findOrderUseCase: FindOrderUseCase
 ) {
     @PostMapping(
         path = ["/v1/orders"],
@@ -148,8 +148,13 @@ class ExternalOrderNumberController(
         }
 
         return (
-            queryStatusUseCase(id, null)
-                ?.let(StatusResponse::Found)
+            findOrderUseCase(id, null)
+                ?.let {
+                    StatusResponse.Found(
+                        status = it.status,
+                        sampledAt = it.sampledAt
+                    )
+                }
                 ?: StatusResponse.NotFound
             )
             .asEntity()

--- a/src/main/kotlin/com/healthmetrix/labres/order/FindOrderUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/FindOrderUseCase.kt
@@ -6,12 +6,11 @@ import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class QueryStatusUseCase(private val repository: OrderInformationRepository) {
+class FindOrderUseCase(private val repository: OrderInformationRepository) {
 
     operator fun invoke(id: UUID, issuerId: String?) = repository
         .findById(id)
         ?.takeIf { it.isIssuedBy(issuerId) }
-        ?.let(OrderInformation::status)
 
     private fun OrderInformation?.isIssuedBy(issuerId: String?) =
         this?.orderNumber?.issuerId == (issuerId ?: EON_ISSUER_ID)

--- a/src/main/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberController.kt
@@ -71,7 +71,7 @@ import java.util.UUID
 class PreIssuedOrderNumberController(
     private val registerOrderUseCase: RegisterOrderUseCase,
     private val updateOrderUseCase: UpdateOrderUseCase,
-    private val queryStatusUseCase: QueryStatusUseCase,
+    private val findOrderUseCase: FindOrderUseCase,
     private val metrics: OrderMetrics
 ) {
     @PostMapping(
@@ -233,7 +233,7 @@ class PreIssuedOrderNumberController(
             return StatusResponse.BadRequest(message).asEntity()
         }
 
-        val result = queryStatusUseCase(id, issuerId)
+        val result = findOrderUseCase(id, issuerId)
 
         return if (result != null) {
             logger.debug(
@@ -243,7 +243,7 @@ class PreIssuedOrderNumberController(
                 kv("orderId", orderId),
                 kv("requestId", requestId)
             )
-            StatusResponse.Found(result).asEntity()
+            StatusResponse.Found(result.status, null).asEntity()
         } else {
             logger.info(
                 "[{}]: Not found",

--- a/src/main/kotlin/com/healthmetrix/labres/order/Status.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/Status.kt
@@ -1,5 +1,6 @@
 package com.healthmetrix.labres.order
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.healthmetrix.labres.LabResApiResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
@@ -21,11 +22,20 @@ enum class Status {
 }
 
 sealed class StatusResponse(httpStatus: HttpStatus, hasBody: Boolean = true) : LabResApiResponse(httpStatus, hasBody) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     data class Found(
         @Schema(
             description = "Status enum to indicate if the lab result is in progress, sample material has been found invalid,  or if it has a positive or negative result"
         )
-        val status: Status
+        val status: Status,
+
+        @Schema(
+            description = "Unix Epoch timestamp when the sample has been taken",
+            nullable = true,
+            required = false,
+            example = "1596184744"
+        )
+        val sampledAt: Long?
     ) : StatusResponse(HttpStatus.OK)
 
     object NotFound : StatusResponse(HttpStatus.NOT_FOUND, false)

--- a/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
@@ -27,7 +27,8 @@ data class OrderInformation(
     val notifiedAt: Date? = null,
     val notificationUrls: List<String> = emptyList(),
     val enteredLabAt: Date? = null,
-    val testType: TestType? = null
+    val testType: TestType? = null,
+    val sampledAt: Long? = null
 ) {
     internal fun raw() = RawOrderInformation(
         id = id,
@@ -42,7 +43,8 @@ data class OrderInformation(
         testType = testType?.toString(),
         labId = labId,
         testSiteId = testSiteId,
-        sample = sample.toString()
+        sample = sample.toString(),
+        sampledAt = sampledAt
     )
 }
 
@@ -86,7 +88,10 @@ data class RawOrderInformation(
     var testType: String? = null,
 
     @DynamoDBAttribute
-    var sample: String? = null
+    var sample: String? = null,
+
+    @DynamoDBAttribute
+    var sampledAt: Long? = null
 ) {
     fun cook(): OrderInformation? {
         // for smart casts
@@ -192,7 +197,8 @@ data class RawOrderInformation(
             reportedAt = reportedAt,
             notifiedAt = notifiedAt,
             enteredLabAt = enteredLabAt,
-            sample = cookedSample
+            sample = cookedSample,
+            sampledAt = sampledAt
         )
     }
 

--- a/src/test/kotlin/com/healthmetrix/labres/integration/IlluminaFlowTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/integration/IlluminaFlowTest.kt
@@ -60,6 +60,8 @@ class IlluminaFlowTest {
     private val fcmToken = "test"
     private val notificationUrl = "fcm://labres@$fcmToken"
 
+    // TODO rewrite this to use bulk upload
+
     @Test
     fun `an order can be registered`() {
         val registeredResponse = registerOrder(Sample.SALIVA)
@@ -97,7 +99,10 @@ class IlluminaFlowTest {
 
         val orderId = registeredResponse.id
         mockMvc.get("/v1/issuers/$issuerId/orders/$orderId")
-            .andExpect { status { isOk } }
+            .andExpect {
+                jsonPath("$.sampledAt") { doesNotExist() }
+                status { isOk }
+            }
 
         uploadResult(TestType.ANTIBODY)
 

--- a/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
@@ -310,6 +310,53 @@ class LabControllerTest {
                 )
             }
         }
+
+        @Test
+        fun `uploading a document with optional value sampledAt returns 200`() {
+            val sampledAt = 1596186947L
+
+            mockMvc.put("/v1/results") {
+                header(HttpHeaders.AUTHORIZATION, labIdHeader)
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(
+                    mapOf(
+                        "orderNumber" to "0123456789",
+                        "result" to Status.NEGATIVE,
+                        "sampledAt" to sampledAt
+                    )
+                )
+            }
+
+            verify {
+                updateResultUseCase.invoke(
+                    updateResultRequest = match {
+                        it.orderNumber == orderNumber &&
+                            it.result == Result.NEGATIVE &&
+                            it.sampledAt == sampledAt
+                    },
+                    labId = labId,
+                    issuerId = null,
+                    now = any()
+                )
+            }
+        }
+
+        @Test
+        fun `uploading a document with optional value sampledAt persists it`() {
+            mockMvc.put("/v1/results") {
+                header(HttpHeaders.AUTHORIZATION, labIdHeader)
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(
+                    mapOf(
+                        "orderNumber" to "0123456789",
+                        "result" to Status.NEGATIVE,
+                        "sampledAt" to 1596186947L
+                    )
+                )
+            }.andExpect {
+                status { isOk }
+            }
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/UpdateResultUseCaseTest.kt
@@ -79,6 +79,23 @@ class UpdateResultUseCaseTest {
     }
 
     @Test
+    fun `updates orderInformation with optional values testType and sampledAt if they're set`() {
+        clearMocks(repository)
+
+        val sampledAt = 1596186947L
+        val testType = TestType.ANTIBODY
+
+        every { repository.findByOrderNumberAndSample(any(), any()) } returns listOf(orderInfo)
+        val updated = updated.copy(status = Status.IN_PROGRESS, enteredLabAt = now, sampledAt = sampledAt, testType = testType)
+        every { repository.save(any()) } returns updated
+        every { notifier.invoke(any(), any()) } returns true
+
+        underTest(updateResultRequest.copy(result = Result.IN_PROGRESS, sampledAt = sampledAt, type = testType), labId, null, now = now)
+
+        verify(exactly = 1) { repository.save(updated) }
+    }
+
+    @Test
     fun `notifies on updated order`() {
         clearMocks(notifier)
 

--- a/src/test/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberControllerTest.kt
@@ -20,9 +20,9 @@ import java.util.UUID
 class ExternalOrderNumberControllerTest {
     private val issueExternalOrderNumberUseCase: IssueExternalOrderNumberUseCase = mockk()
     private val updateOrderUseCase: UpdateOrderUseCase = mockk()
-    private val queryStatusUseCase: QueryStatusUseCase = mockk()
+    private val findOrderUseCase: FindOrderUseCase = mockk()
 
-    private val underTest = ExternalOrderNumberController(issueExternalOrderNumberUseCase, updateOrderUseCase, queryStatusUseCase)
+    private val underTest = ExternalOrderNumberController(issueExternalOrderNumberUseCase, updateOrderUseCase, findOrderUseCase)
 
     private val objectMapper = ObjectMapper().registerKotlinModule()
     private val mockMvc = MockMvcBuilders.standaloneSetup(underTest).build()
@@ -165,7 +165,7 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `querying the status of an order returns 200`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns Status.POSITIVE
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE)
 
             mockMvc.get("/v1/orders/$orderId").andExpect {
                 status { isOk }
@@ -174,10 +174,29 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `querying the status of an order returns status`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns Status.POSITIVE
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE)
 
             mockMvc.get("/v1/orders/$orderId").andExpect {
                 jsonPath("$.status", Is.`is`(Status.POSITIVE.toString()))
+            }
+        }
+
+        @Test
+        fun `querying the status of an order does not return sampledAt if it is not set in the database`() {
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE)
+
+            mockMvc.get("/v1/orders/$orderId").andExpect {
+                jsonPath("$.sampledAt") { doesNotExist() }
+            }
+        }
+
+        @Test
+        fun `querying the status of an order returns sampledAt`() {
+            val sampledAt: Long = 1596186947
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE, sampledAt = sampledAt)
+
+            mockMvc.get("/v1/orders/$orderId").andExpect {
+                jsonPath("$.sampledAt", Is.`is`(sampledAt.toInt()))
             }
         }
 
@@ -190,7 +209,7 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `returns status 404 when no order is found`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns null
+            every { findOrderUseCase.invoke(any(), any()) } returns null
             mockMvc.get("/v1/orders/$orderId").andExpect {
                 status { isNotFound }
             }

--- a/src/test/kotlin/com/healthmetrix/labres/order/FindOrderUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/FindOrderUseCaseTest.kt
@@ -10,10 +10,10 @@ import java.time.Instant
 import java.util.Date
 import java.util.UUID
 
-internal class QueryStatusUseCaseTest {
+internal class FindOrderUseCaseTest {
 
     private val repository: OrderInformationRepository = mockk()
-    private val underTest = QueryStatusUseCase(repository)
+    private val underTest = FindOrderUseCase(repository)
 
     private val orderStatus = Status.IN_PROGRESS
     private val orderId = UUID.randomUUID()
@@ -32,14 +32,14 @@ internal class QueryStatusUseCaseTest {
     fun `it should return the order status for eon`() {
         every { repository.findById(any()) } returns orderInformation
 
-        assertThat(underTest(orderId, null)).isEqualTo(orderStatus)
+        assertThat(underTest(orderId, null)).isEqualTo(orderInformation)
     }
 
     @Test
     fun `it should return the order status for pon`() {
         every { repository.findById(any()) } returns orderInformation.copy(orderNumber = pon)
 
-        assertThat(underTest(orderId, issuerId)).isEqualTo(orderStatus)
+        assertThat(underTest(orderId, issuerId)).isEqualTo(orderInformation.copy(orderNumber = pon))
     }
 
     @Test

--- a/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
@@ -25,11 +25,11 @@ import java.util.UUID
 class PreIssuedOrderNumberControllerTest {
     private val registerOrderUseCase: RegisterOrderUseCase = mockk()
     private val updateOrderUseCase: UpdateOrderUseCase = mockk()
-    private val queryStatusUseCase: QueryStatusUseCase = mockk()
+    private val findOrderUseCase: FindOrderUseCase = mockk()
     private val metrics: OrderMetrics = mockk(relaxUnitFun = true)
 
     private val underTest =
-        PreIssuedOrderNumberController(registerOrderUseCase, updateOrderUseCase, queryStatusUseCase, metrics)
+        PreIssuedOrderNumberController(registerOrderUseCase, updateOrderUseCase, findOrderUseCase, metrics)
     private val mockMvc = MockMvcBuilders.standaloneSetup(underTest).build()
 
     private val objectMapper = ObjectMapper().registerKotlinModule()
@@ -138,7 +138,7 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `querying the status of an order returns 200`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns Status.POSITIVE
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE)
 
             mockMvc.get("/v1/issuers/$issuerId/orders/$orderId").andExpect {
                 status { isOk }
@@ -147,10 +147,19 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `querying the status of an order returns status`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns Status.POSITIVE
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE)
 
             mockMvc.get("/v1/issuers/$issuerId/orders/$orderId").andExpect {
                 jsonPath("$.status", Is.`is`(Status.POSITIVE.toString()))
+            }
+        }
+
+        @Test
+        fun `querying the status of an order does not set sampledAt on the response`() {
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE, sampledAt = 1596186947L)
+
+            mockMvc.get("/v1/issuers/$issuerId/orders/$orderId").andExpect {
+                jsonPath("$.sampledAt") { doesNotExist() }
             }
         }
 
@@ -163,7 +172,7 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `returns status 404 when no order is found`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns null
+            every { findOrderUseCase.invoke(any(), any()) } returns null
             mockMvc.get("/v1/issuers/$issuerId/orders/$orderId").andExpect {
                 status { isNotFound }
             }
@@ -272,27 +281,27 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `querying the status of an order for issuerId hpi should transform it to mvz`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns Status.POSITIVE
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE)
 
             val issuerId = "hpi"
 
             mockMvc.get("/v1/issuers/$issuerId/orders/$orderId")
 
             verify(exactly = 1) {
-                queryStatusUseCase.invoke(any(), "mvz")
+                findOrderUseCase.invoke(any(), "mvz")
             }
         }
 
         @Test
         fun `querying the status of an order for issuerId wmt should transform it to mvz`() {
-            every { queryStatusUseCase.invoke(any(), any()) } returns Status.POSITIVE
+            every { findOrderUseCase.invoke(any(), any()) } returns order.copy(status = Status.POSITIVE)
 
             val issuerId = "wmt"
 
             mockMvc.get("/v1/issuers/$issuerId/orders/$orderId")
 
             verify(exactly = 1) {
-                queryStatusUseCase.invoke(any(), "mvz")
+                findOrderUseCase.invoke(any(), "mvz")
             }
         }
 

--- a/src/test/kotlin/com/healthmetrix/labres/persistence/RawOrderInformationTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/persistence/RawOrderInformationTest.kt
@@ -25,6 +25,7 @@ internal class RawOrderInformationTest {
     private val labId = "test-lab"
     private val testSiteId = "test-test-site"
     private val orderNumberString = "1234567890"
+    private val sampledAt = 1596186947L
 
     private val raw = RawOrderInformation(
         id = id,
@@ -39,7 +40,8 @@ internal class RawOrderInformationTest {
         issuedAt = issuedAt,
         enteredLabAt = enteredLabAt,
         reportedAt = reportedAt,
-        notifiedAt = notifiedAt
+        notifiedAt = notifiedAt,
+        sampledAt = sampledAt
     )
 
     private val cooked = OrderInformation(
@@ -54,7 +56,8 @@ internal class RawOrderInformationTest {
         reportedAt = reportedAt,
         notifiedAt = notifiedAt,
         enteredLabAt = enteredLabAt,
-        sample = Sample.BLOOD
+        sample = Sample.BLOOD,
+        sampledAt = sampledAt
     )
 
     @Nested
@@ -74,7 +77,8 @@ internal class RawOrderInformationTest {
                 labId = null,
                 testSiteId = null,
                 testType = null,
-                enteredLabAt = null
+                enteredLabAt = null,
+                sampledAt = null
             ).cook()
 
             val expected = cooked.copy(
@@ -84,7 +88,8 @@ internal class RawOrderInformationTest {
                 labId = null,
                 testSiteId = null,
                 testType = null,
-                enteredLabAt = null
+                enteredLabAt = null,
+                sampledAt = null
             )
 
             assertThat(result).isEqualTo(expected)
@@ -199,7 +204,8 @@ internal class RawOrderInformationTest {
                 notifiedAt = null,
                 notificationUrls = emptyList(),
                 enteredLabAt = null,
-                testType = null
+                testType = null,
+                sampledAt = null
             ).raw()
 
             val expected = raw.copy(
@@ -209,7 +215,8 @@ internal class RawOrderInformationTest {
                 labId = null,
                 testSiteId = null,
                 testType = null,
-                enteredLabAt = null
+                enteredLabAt = null,
+                sampledAt = null
             )
 
             assertThat(result).isEqualTo(expected)


### PR DESCRIPTION
Optional sampledAt timestamp can be set when updating a result for an
order. It will also be returned when querying the status of an
externally issued order

See https://github.com/healthmetrix/labres/issues/11