### PR TITLE
Add verification secret to issue EON requests

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberController.kt
@@ -115,7 +115,8 @@ class ExternalOrderNumberController(
 
         return issueExternalOrderNumber(
             notificationUrl = request?.notificationUrl,
-            sample = request?.sample ?: Sample.SALIVA
+            sample = request?.sample ?: Sample.SALIVA,
+            verificationSecret = request?.verificationSecret
         ).onFailure { msg ->
             logger.warn(
                 "[{}] Order already exists: $msg",
@@ -336,7 +337,16 @@ class ExternalOrderNumberController(
             defaultValue = "SALIVA",
             example = "BLOOD"
         )
-        val sample: Sample = Sample.SALIVA
+        val sample: Sample = Sample.SALIVA,
+
+        @Schema(
+            description = "Verification secret that has to be presented when querying the status on an order by EON",
+            nullable = true,
+            required = false,
+            defaultValue = "null",
+            example = "3ASsdfSA*SFDnj!f"
+        )
+        val verificationSecret: String? = null
     )
 
     sealed class IssueExternalOrderNumberResponse(httpStatus: HttpStatus, hasBody: Boolean = true) :

--- a/src/main/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCase.kt
@@ -12,13 +12,18 @@ class IssueExternalOrderNumberUseCase(
     private val repository: OrderInformationRepository,
     private val registerOrder: RegisterOrderUseCase
 ) {
-    operator fun invoke(notificationUrl: String?, sample: Sample): Result<OrderInformation, String> {
+    operator fun invoke(
+        notificationUrl: String?,
+        sample: Sample,
+        verificationSecret: String?
+    ): Result<OrderInformation, String> {
         val eon = issueNewEon()
-        return registerOrder(
+        return registerOrder.invoke(
             eon,
             testSiteId = null,
             notificationUrl = notificationUrl,
-            sample = sample
+            sample = sample,
+            verificationSecret = verificationSecret
         )
     }
 

--- a/src/main/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberController.kt
@@ -127,11 +127,12 @@ class PreIssuedOrderNumberController(
             kv("requestId", requestId)
         )
 
-        return registerOrderUseCase(
+        return registerOrderUseCase.invoke(
             orderNumber = OrderNumber.from(issuerId, request.orderNumber),
             testSiteId = request.testSiteId,
             sample = request.sample,
-            notificationUrl = request.notificationUrl
+            notificationUrl = request.notificationUrl,
+            verificationSecret = null
         ).onFailure { msg ->
             logger.warn(
                 "[{}] Order already exists: $msg",

--- a/src/main/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/RegisterOrderUseCase.kt
@@ -23,7 +23,8 @@ class RegisterOrderUseCase(
         testSiteId: String?,
         sample: Sample,
         notificationUrl: String?,
-        now: Instant = Instant.now()
+        now: Instant = Instant.now(),
+        verificationSecret: String?
     ): Result<OrderInformation, String> {
         val existingOrders = repository.findByOrderNumberAndSample(orderNumber, sample)
 
@@ -35,7 +36,8 @@ class RegisterOrderUseCase(
                 notificationUrls = listOfNotNull(notificationUrl),
                 issuedAt = Date.from(now),
                 testSiteId = testSiteId,
-                sample = sample
+                sample = sample,
+                verificationSecret = verificationSecret
             ).let(repository::save).let(::Ok)
 
         if (!newestExisting.notificationUrls.contains(notificationUrl)) {
@@ -61,6 +63,7 @@ class RegisterOrderUseCase(
             testSiteId = testSiteId,
             issuedAt = Date.from(now),
             notificationUrls = mergeNotificationUrls(newestExisting.notificationUrls, notificationUrl)
+            // don't update verification secret
         ).let(repository::save).let(::Ok)
     }
 

--- a/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
@@ -28,7 +28,8 @@ data class OrderInformation(
     val notificationUrls: List<String> = emptyList(),
     val enteredLabAt: Date? = null,
     val testType: TestType? = null,
-    val sampledAt: Long? = null
+    val sampledAt: Long? = null,
+    val verificationSecret: String? = null
 ) {
     internal fun raw() = RawOrderInformation(
         id = id,
@@ -44,7 +45,8 @@ data class OrderInformation(
         labId = labId,
         testSiteId = testSiteId,
         sample = sample.toString(),
-        sampledAt = sampledAt
+        sampledAt = sampledAt,
+        verificationSecret = verificationSecret
     )
 }
 
@@ -91,7 +93,10 @@ data class RawOrderInformation(
     var sample: String? = null,
 
     @DynamoDBAttribute
-    var sampledAt: Long? = null
+    var sampledAt: Long? = null,
+
+    @DynamoDBAttribute
+    var verificationSecret: String? = null
 ) {
     fun cook(): OrderInformation? {
         // for smart casts
@@ -198,7 +203,8 @@ data class RawOrderInformation(
             notifiedAt = notifiedAt,
             enteredLabAt = enteredLabAt,
             sample = cookedSample,
-            sampledAt = sampledAt
+            sampledAt = sampledAt,
+            verificationSecret = verificationSecret
         )
     }
 

--- a/src/test/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/ExternalOrderNumberControllerTest.kt
@@ -48,7 +48,7 @@ class ExternalOrderNumberControllerTest {
     inner class CreateOrderEndpointWithoutNotificationUrlTest {
         @Test
         fun `issuing an external order number returns status 201`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             mockMvc.post("/v1/orders") {
                 contentType = MediaType.APPLICATION_JSON
@@ -59,7 +59,7 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `issuing an external order number returns order number and id`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             mockMvc.post("/v1/orders") {
                 contentType = MediaType.APPLICATION_JSON
@@ -74,7 +74,7 @@ class ExternalOrderNumberControllerTest {
     inner class CreateOrderEndpointWithNotificationUrlTest {
         @Test
         fun `issuing an external order number returns status 201`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = "http://test.test")
 
@@ -88,7 +88,7 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `issuing an external order number returns order number and id`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = "http://test.test")
 
@@ -106,7 +106,7 @@ class ExternalOrderNumberControllerTest {
     inner class CreateOrderEndpointWithSalivaTest {
         @Test
         fun `issuing an external order number returns status 201`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.SALIVA)
 
@@ -120,7 +120,7 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `issuing an external order number returns order number and id`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.SALIVA)
 
@@ -138,7 +138,7 @@ class ExternalOrderNumberControllerTest {
     inner class CreateOrderEndpointWithBloodTest {
         @Test
         fun `issuing an external order number returns status 201`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.BLOOD)
 
@@ -152,9 +152,50 @@ class ExternalOrderNumberControllerTest {
 
         @Test
         fun `issuing an external order number returns order number and id`() {
-            every { issueExternalOrderNumberUseCase.invoke(any(), any()) } returns Ok(order)
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
 
             val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(notificationUrl = null, sample = Sample.BLOOD)
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                jsonPath("$.orderNumber") { isString }
+                jsonPath("$.id") { isString }
+            }
+        }
+    }
+
+    @Nested
+    inner class CreateOrderWithVerificationSecretTest {
+
+        val secret = UUID.randomUUID().toString()
+
+        @Test
+        fun `issuing an external order number returns status 201`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(
+                notificationUrl = null,
+                verificationSecret = secret
+            )
+
+            mockMvc.post("/v1/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated }
+            }
+        }
+
+        @Test
+        fun `issuing an external order number returns order number and id`() {
+            every { issueExternalOrderNumberUseCase.invoke(any(), any(), any()) } returns Ok(order)
+
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(
+                notificationUrl = null,
+                verificationSecret = secret
+            )
 
             mockMvc.post("/v1/orders") {
                 contentType = MediaType.APPLICATION_JSON

--- a/src/test/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCaseTest.kt
@@ -34,9 +34,9 @@ internal class IssueExternalOrderNumberUseCaseTest {
     @Test
     fun `it returns registered orderId and orderNumber`() {
         every { repository.findByOrderNumber(any()) } returns emptyList()
-        every { registerOrder(any(), any(), any(), any(), any()) } returns Ok(order)
+        every { registerOrder.invoke(any(), any(), any(), any(), any(), any()) } returns Ok(order)
 
-        assertThat(underTest(notificationUrl, Sample.SALIVA).unwrap()).isEqualTo(order)
+        assertThat(underTest(notificationUrl, Sample.SALIVA, null).unwrap()).isEqualTo(order)
     }
 
     @Test
@@ -46,27 +46,28 @@ internal class IssueExternalOrderNumberUseCaseTest {
             listOf(orderInformation, orderInformation),
             emptyList()
         )
-        every { registerOrder(any(), any(), any(), any(), any()) } returns Ok(order)
+        every { registerOrder.invoke(any(), any(), any(), any(), any(), any()) } returns Ok(order)
 
-        underTest(notificationUrl, Sample.SALIVA)
+        underTest(notificationUrl, Sample.SALIVA, null)
 
-        verify { registerOrder(any(), null, any(), notificationUrl, any()) }
+        verify { registerOrder.invoke(any(), null, any(), notificationUrl, any(), null) }
     }
 
     @Test
     fun `it calls registerOrder with default sample type SALIVA`() {
         every { repository.findByOrderNumber(any()) } returns emptyList()
-        every { registerOrder(any(), any(), any(), any(), any()) } returns Ok(order)
+        every { registerOrder.invoke(any(), any(), any(), any(), any(), any()) } returns Ok(order)
 
-        underTest(notificationUrl, Sample.SALIVA)
+        underTest(notificationUrl, Sample.SALIVA, null)
 
         verify {
-            registerOrder(
+            registerOrder.invoke(
                 orderNumber = any(),
                 testSiteId = any(),
                 sample = Sample.SALIVA,
                 notificationUrl = any(),
-                now = any()
+                now = any(),
+                verificationSecret = null
             )
         }
     }

--- a/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
@@ -58,7 +58,7 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `registering a preissued order number returns status 201`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any()) } returns Ok(order)
+            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
 
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = orderNumberString,
@@ -76,7 +76,7 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `registering a preissued order number for kevb with more than 8 digits truncates the analyt`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any()) } returns Ok(order)
+            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
 
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = "0123456799",
@@ -91,13 +91,13 @@ class PreIssuedOrderNumberControllerTest {
 
             val correct = OrderNumber.from("kevb", "01234567")
             verify(exactly = 1) {
-                registerOrderUseCase.invoke(eq(correct), any(), any(), any(), any())
+                registerOrderUseCase.invoke(eq(correct), any(), any(), any(), any(), null)
             }
         }
 
         @Test
         fun `registering a preissued order number returns order number and id`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any()) } returns Ok(order)
+            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
 
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = orderNumberString,
@@ -116,7 +116,7 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `registering a preissued order number returns 409 if it has already been registered before`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any()) } returns Err("already exists")
+            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Err("already exists")
 
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = orderNumberString,
@@ -235,7 +235,7 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `registering a preissued order number for for issuerId hpi should transform it to mvz`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any()) } returns Ok(order)
+            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
 
             val issuerId = "hpi"
 
@@ -252,13 +252,13 @@ class PreIssuedOrderNumberControllerTest {
 
             val expected = OrderNumber.from("mvz", "01234567")
             verify(exactly = 1) {
-                registerOrderUseCase.invoke(eq(expected), any(), any(), any(), any())
+                registerOrderUseCase.invoke(eq(expected), any(), any(), any(), any(), any())
             }
         }
 
         @Test
         fun `registering a preissued order number for for issuerId wmt should transform it to mvz`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any()) } returns Ok(order)
+            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
 
             val issuerId = "wmt"
 
@@ -275,7 +275,7 @@ class PreIssuedOrderNumberControllerTest {
 
             val expected = OrderNumber.from("mvz", "01234567")
             verify(exactly = 1) {
-                registerOrderUseCase.invoke(eq(expected), any(), any(), any(), any())
+                registerOrderUseCase.invoke(eq(expected), any(), any(), any(), any(), any())
             }
         }
 

--- a/src/test/kotlin/com/healthmetrix/labres/persistence/RawOrderInformationTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/persistence/RawOrderInformationTest.kt
@@ -26,6 +26,7 @@ internal class RawOrderInformationTest {
     private val testSiteId = "test-test-site"
     private val orderNumberString = "1234567890"
     private val sampledAt = 1596186947L
+    private val verificationSecret = UUID.randomUUID().toString()
 
     private val raw = RawOrderInformation(
         id = id,
@@ -41,7 +42,8 @@ internal class RawOrderInformationTest {
         enteredLabAt = enteredLabAt,
         reportedAt = reportedAt,
         notifiedAt = notifiedAt,
-        sampledAt = sampledAt
+        sampledAt = sampledAt,
+        verificationSecret = verificationSecret
     )
 
     private val cooked = OrderInformation(
@@ -57,7 +59,8 @@ internal class RawOrderInformationTest {
         notifiedAt = notifiedAt,
         enteredLabAt = enteredLabAt,
         sample = Sample.BLOOD,
-        sampledAt = sampledAt
+        sampledAt = sampledAt,
+        verificationSecret = verificationSecret
     )
 
     @Nested
@@ -78,7 +81,8 @@ internal class RawOrderInformationTest {
                 testSiteId = null,
                 testType = null,
                 enteredLabAt = null,
-                sampledAt = null
+                sampledAt = null,
+                verificationSecret = null
             ).cook()
 
             val expected = cooked.copy(
@@ -89,7 +93,8 @@ internal class RawOrderInformationTest {
                 testSiteId = null,
                 testType = null,
                 enteredLabAt = null,
-                sampledAt = null
+                sampledAt = null,
+                verificationSecret = null
             )
 
             assertThat(result).isEqualTo(expected)
@@ -205,7 +210,8 @@ internal class RawOrderInformationTest {
                 notificationUrls = emptyList(),
                 enteredLabAt = null,
                 testType = null,
-                sampledAt = null
+                sampledAt = null,
+                verificationSecret = null
             ).raw()
 
             val expected = raw.copy(
@@ -216,7 +222,8 @@ internal class RawOrderInformationTest {
                 testSiteId = null,
                 testType = null,
                 enteredLabAt = null,
-                sampledAt = null
+                sampledAt = null,
+                verificationSecret = null
             )
 
             assertThat(result).isEqualTo(expected)


### PR DESCRIPTION
Add optional parameter verification secret to issue EON requests and
persist it in the DB

--> https://github.com/healthmetrix/labres/issues/12