### PR TITLE
Add verificationSecret as optional param to updateResult endpoint

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/lab/LabController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/LabController.kt
@@ -329,7 +329,16 @@ data class UpdateResultRequest(
         required = false,
         example = "1596184744"
     )
-    val sampledAt: Long? = null
+    val sampledAt: Long? = null,
+
+    @Schema(
+        description = "Verification secret that has to be presented when querying the status on an order by EON",
+        nullable = true,
+        required = false,
+        defaultValue = "null",
+        example = "3ASsdfSA*SFDnj!f"
+    )
+    val verificationSecret: String? = null
 )
 
 sealed class UpdateResultResponse(

--- a/src/main/kotlin/com/healthmetrix/labres/lab/LabMetrics.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/lab/LabMetrics.kt
@@ -43,6 +43,22 @@ class LabMetrics(
         .register(meterRegistry) // idempotent
         .increment()
 
+    fun countOverwritingVerificationSecret(labId: String, issuerId: String?): Unit = Counter
+        .builder("issuers.${issuerId ?: EON_ISSUER_ID}.labs.$labId.overwriteVerificationSecret")
+        .description("Increments the sum overwriting verificationSecrets for issuer $issuerId and $labId")
+        .tags(
+            listOf(
+                Tag.of("api", "lab"),
+                Tag.of("operation", "updateResult"),
+                Tag.of("metric", "count"),
+                Tag.of("scope", "updateResult"),
+                Tag.of("issuerId", issuerId ?: EON_ISSUER_ID),
+                Tag.of("labId", labId)
+            )
+        )
+        .register(meterRegistry) // idempotent
+        .increment()
+
     fun countUnauthorized() = Counter
         .builder("labApi.unauthorized")
         .description("Increments the sum of unauthorized requests on the lab facing API")


### PR DESCRIPTION
Labs can also set a verificationSecret optionally. If they do so and
there is already an existing one, the lab value overwrites the existing.