### PR TITLE
Overwrite verificationSecret on updateResult only if not null

### DIFF
--- a/src/test/kotlin/com/healthmetrix/labres/integration/ChariteFlowTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/integration/ChariteFlowTest.kt
@@ -149,7 +149,7 @@ class ChariteFlowTest {
 
             repository.save(order)
 
-            val actual = mockMvc.get("/v1/orders") {
+            mockMvc.get("/v1/orders") {
                 param("orderNumber", orderNumberString)
                 param("verificationSecret", "wrong")
                 param("sample", Sample.BLOOD.toString())
@@ -173,7 +173,7 @@ class ChariteFlowTest {
 
             repository.save(order)
 
-            val actual = mockMvc.get("/v1/orders") {
+            mockMvc.get("/v1/orders") {
                 param("orderNumber", orderNumberString)
                 param("verificationSecret", "wrong")
                 param("sample", Sample.BLOOD.toString())
@@ -215,6 +215,24 @@ class ChariteFlowTest {
             val updatedOrderInformation = repository.findById(orderId)
             assertThat(updatedOrderInformation).isNotNull
             assertThat(updatedOrderInformation!!.verificationSecret).isEqualTo(verificationSecret)
+        }
+
+        @Test
+        fun `updating results doesn't overwrite verificationSecret if verificationSecret is null on the request`() {
+            val firstVerificationSecret = "first"
+            val createResponse = registerOrder(null, sample, firstVerificationSecret)
+
+            val orderId = createResponse.id
+            val orderNumber = createResponse.orderNumber
+
+            val orderInformation = repository.findById(orderId)!!
+            assertThat(orderInformation.verificationSecret).isEqualTo(firstVerificationSecret)
+
+            updateResultFor(orderNumber, null, null, null)
+
+            val updatedOrderInformation = repository.findById(orderId)
+            assertThat(updatedOrderInformation).isNotNull
+            assertThat(updatedOrderInformation!!.verificationSecret).isEqualTo(firstVerificationSecret)
         }
     }
 

--- a/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/lab/LabControllerTest.kt
@@ -362,8 +362,6 @@ class LabControllerTest {
 
         @Test
         fun `uploading a document with optional value verificationSecret returns 200`() {
-            val sampledAt = 1596186947L
-
             mockMvc.put("/v1/results") {
                 header(HttpHeaders.AUTHORIZATION, labIdHeader)
                 contentType = MediaType.APPLICATION_JSON


### PR DESCRIPTION
If the verificationSecret is set in the database, this value should not be overwritten by a null value in the updateResult request from a lab.