### PR TITLE
Add property metadata to preissued orders

### DIFF
--- a/src/main/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCase.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCase.kt
@@ -21,9 +21,11 @@ class IssueExternalOrderNumberUseCase(
         return registerOrder.invoke(
             eon,
             testSiteId = null,
-            notificationUrl = notificationUrl,
             sample = sample,
-            verificationSecret = verificationSecret
+            notificationUrl = notificationUrl,
+            verificationSecret = verificationSecret,
+            sampledAt = null,
+            metadata = null
         )
     }
 

--- a/src/main/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberController.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberController.kt
@@ -1,5 +1,6 @@
 package com.healthmetrix.labres.order
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.github.michaelbull.result.map
 import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.onFailure
@@ -132,7 +133,9 @@ class PreIssuedOrderNumberController(
             testSiteId = request.testSiteId,
             sample = request.sample,
             notificationUrl = request.notificationUrl,
-            verificationSecret = null
+            verificationSecret = null,
+            sampledAt = request.sampledAt,
+            metadata = request.metadata
         ).onFailure { msg ->
             logger.warn(
                 "[{}] Order already exists: $msg",
@@ -397,7 +400,15 @@ class PreIssuedOrderNumberController(
             required = false,
             example = "1596184744"
         )
-        val sampledAt: Long? = null
+        val sampledAt: Long? = null,
+        @Schema(
+            description = "Any metadata to the order",
+            type = "object",
+            nullable = true,
+            required = false,
+            example = "{\"hello\":\"world\"}"
+        )
+        val metadata: JsonNode? = null
     )
 
     sealed class RegisterOrderResponse(httpStatus: HttpStatus, hasBody: Boolean = true) :

--- a/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
+++ b/src/main/kotlin/com/healthmetrix/labres/persistence/OrderInformation.kt
@@ -5,6 +5,8 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConvertedJson
+import com.fasterxml.jackson.databind.JsonNode
 import com.healthmetrix.labres.lab.TestType
 import com.healthmetrix.labres.logger
 import com.healthmetrix.labres.order.OrderNumber
@@ -29,7 +31,8 @@ data class OrderInformation(
     val enteredLabAt: Date? = null,
     val testType: TestType? = null,
     val sampledAt: Long? = null,
-    val verificationSecret: String? = null
+    val verificationSecret: String? = null,
+    val metadata: JsonNode? = null
 ) {
     internal fun raw() = RawOrderInformation(
         id = id,
@@ -46,7 +49,8 @@ data class OrderInformation(
         testSiteId = testSiteId,
         sample = sample.toString(),
         sampledAt = sampledAt,
-        verificationSecret = verificationSecret
+        verificationSecret = verificationSecret,
+        metadata = metadata
     )
 }
 
@@ -96,7 +100,11 @@ data class RawOrderInformation(
     var sampledAt: Long? = null,
 
     @DynamoDBAttribute
-    var verificationSecret: String? = null
+    var verificationSecret: String? = null,
+
+    @DynamoDBAttribute
+    @DynamoDBTypeConvertedJson
+    var metadata: JsonNode? = null
 ) {
     fun cook(): OrderInformation? {
         // for smart casts
@@ -204,7 +212,8 @@ data class RawOrderInformation(
             enteredLabAt = enteredLabAt,
             sample = cookedSample,
             sampledAt = sampledAt,
-            verificationSecret = verificationSecret
+            verificationSecret = verificationSecret,
+            metadata = metadata
         )
     }
 

--- a/src/test/kotlin/com/healthmetrix/labres/integration/AbstractIntegrationTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/integration/AbstractIntegrationTest.kt
@@ -1,0 +1,209 @@
+package com.healthmetrix.labres.integration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.healthmetrix.labres.LabResApplication
+import com.healthmetrix.labres.lab.Result
+import com.healthmetrix.labres.lab.TestType
+import com.healthmetrix.labres.lab.UpdateResultRequest
+import com.healthmetrix.labres.order.ExternalOrderNumberController
+import com.healthmetrix.labres.order.PreIssuedOrderNumberController
+import com.healthmetrix.labres.order.Sample
+import com.healthmetrix.labres.order.Status
+import com.healthmetrix.labres.order.StatusResponse
+import com.healthmetrix.labres.persistence.InMemoryOrderInformationRepository
+import com.healthmetrix.labres.persistence.OrderInformation
+import com.healthmetrix.labres.persistence.OrderInformationRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.joda.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import java.util.UUID
+
+@SpringBootTest(
+    classes = [LabResApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@AutoConfigureMockMvc
+abstract class AbstractIntegrationTest {
+    @Autowired
+    protected lateinit var repository: OrderInformationRepository
+
+    @Autowired
+    protected final lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    protected lateinit var mockMvc: MockMvc
+
+    protected val orderNumber = UUID.randomUUID().toString()
+    protected val issuerId = "test_issuer"
+    protected val testSiteId = "test_test_site"
+    protected val httpNotificationUrl = "http://notify.test"
+    protected val fcmNotificationUrl = "fcm://labres@notify.test"
+    protected val sampledAt = Instant.now().millis
+
+    @BeforeEach
+    internal fun setUp() {
+        (repository as InMemoryOrderInformationRepository).clear()
+    }
+
+    fun assertThatOrderHasBeenSaved(
+        id: UUID,
+        orderNumber: String? = null,
+        issuerId: String? = null,
+        status: Status? = null,
+        testSiteId: String? = null,
+        notificationUrl: String? = null,
+        sample: Sample? = null,
+        sampledAt: Long? = null,
+        metadata: JsonNode? = null,
+        verificationSecret: String? = null,
+        labId: String? = null,
+        testType: TestType? = null
+    ): OrderInformation {
+        val result = repository.findById(id)
+
+        assertThat(result).isNotNull
+
+        result?.apply {
+            if (orderNumber != null)
+                assertThat(this.orderNumber.number).isEqualTo(orderNumber)
+
+            if (issuerId != null)
+                assertThat(this.orderNumber.issuerId).isEqualTo(issuerId)
+
+            if (testSiteId != null)
+                assertThat(testSiteId).isEqualTo(testSiteId)
+
+            if (notificationUrl != null)
+                assertThat(notificationUrls).contains(notificationUrl)
+
+            if (sample != null)
+                assertThat(sample).isEqualTo(sample)
+
+            if (sampledAt != null)
+                assertThat(sampledAt).isEqualTo(sampledAt)
+
+            if (metadata != null)
+                assertThat(metadata).isEqualTo(metadata)
+
+            if (verificationSecret != null)
+                assertThat(verificationSecret).isEqualTo(verificationSecret)
+
+            if (status != null)
+                assertThat(status).isEqualTo(status)
+
+            if (labId != null)
+                assertThat(labId).isEqualTo(labId)
+
+            if (testType != null)
+                assertThat(testType).isEqualTo(testType)
+        }
+
+        return result!!
+    }
+
+    fun registerOrder(
+        orderNumber: String,
+        issuerId: String,
+        testSiteId: String? = null,
+        notificationUrl: String? = null,
+        sample: Sample = Sample.SALIVA,
+        sampledAt: Long? = null,
+        metadata: JsonNode? = null
+    ): PreIssuedOrderNumberController.RegisterOrderResponse.Created =
+        mockMvc.post("/v1/issuers/$issuerId/orders") {
+            val request = PreIssuedOrderNumberController.RegisterOrderRequest(
+                orderNumber = orderNumber,
+                testSiteId = testSiteId,
+                notificationUrl = notificationUrl,
+                sample = sample,
+                sampledAt = sampledAt,
+                metadata = metadata
+            )
+
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsBytes(request)
+        }.andReturn().responseBody()
+
+    fun issueEon(
+        notificationUrl: String? = null,
+        sample: Sample = Sample.SALIVA,
+        verificationSecret: String? = null
+    ): ExternalOrderNumberController.IssueExternalOrderNumberResponse.Created =
+        mockMvc.post("/v1/orders") {
+            contentType = MediaType.APPLICATION_JSON
+            val request = ExternalOrderNumberController.IssueExternalOrderNumberRequestBody(
+                notificationUrl = notificationUrl,
+                sample = sample,
+                verificationSecret = verificationSecret
+            )
+            content = objectMapper.writeValueAsBytes(request)
+        }.andReturn().responseBody()
+
+    fun updateResultFor(
+        orderNumber: String,
+        issuerId: String? = null,
+        labIdHeader: String,
+        result: Result,
+        testType: TestType = TestType.PCR,
+        sampledAt: Long? = null,
+        verificationSecret: String? = null
+    ) = mockMvc.put("/v1/results") {
+        contentType = MediaType.APPLICATION_JSON
+        headers { setBasicAuth(labIdHeader) }
+
+        if (issuerId != null)
+            param("issuerId", issuerId)
+
+        val request = UpdateResultRequest(
+            orderNumber = orderNumber,
+            result = result,
+            verificationSecret = verificationSecret,
+            sampledAt = sampledAt,
+            type = testType
+        )
+
+        content = objectMapper.writeValueAsBytes(request)
+    }.andExpect { status { isOk } }
+
+    fun getResultByOrderNumber(
+        orderNumber: String,
+        verificationSecret: String,
+        sample: Sample? = null
+    ): StatusResponse.Found = mockMvc.get("/v1/orders") {
+        param("orderNumber", orderNumber)
+        param("verificationSecret", verificationSecret)
+
+        if (sample != null)
+            param("sample", sample.toString())
+    }.andExpect {
+        status { isOk }
+    }.andReturn().responseBody()
+
+    fun getResultByOrderId(
+        id: UUID,
+        issuerId: String? = null
+    ): StatusResponse.Found {
+        val url = if (issuerId == null) {
+            "/v1/orders/$id"
+        } else {
+            "/v1/issuers/$issuerId/orders/$id"
+        }
+
+        return mockMvc.get(url).andReturn().responseBody()
+    }
+
+    private inline fun <reified T> MvcResult.responseBody(): T {
+        return objectMapper.readValue(response.contentAsString)
+    }
+}

--- a/src/test/kotlin/com/healthmetrix/labres/integration/LmsFlowTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/integration/LmsFlowTest.kt
@@ -1,0 +1,37 @@
+package com.healthmetrix.labres.integration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.healthmetrix.labres.order.LmsTicketIdentifier
+import com.healthmetrix.labres.order.Sample
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class LmsFlowTest : AbstractIntegrationTest() {
+    private val sample = Sample.SALIVA
+
+    private val ticket = LmsTicketIdentifier(event = "sp-1", ticket = UUID.randomUUID().toString())
+    private val metadata: JsonNode by lazy { objectMapper.valueToTree<JsonNode>(ticket) }
+
+    @Test
+    fun `an orderInformation can be created with a notification url`() {
+        val registeredResponse = registerOrder(
+            orderNumber = orderNumber,
+            issuerId = issuerId,
+            testSiteId = testSiteId,
+            notificationUrl = fcmNotificationUrl,
+            sample = Sample.SALIVA,
+            sampledAt = sampledAt,
+            metadata = metadata
+        )
+
+        assertThatOrderHasBeenSaved(
+            id = registeredResponse.id,
+            orderNumber = orderNumber,
+            issuerId = issuerId,
+            testSiteId = testSiteId,
+            sample = sample,
+            sampledAt = sampledAt,
+            metadata = metadata
+        )
+    }
+}

--- a/src/test/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCaseTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/IssueExternalOrderNumberUseCaseTest.kt
@@ -34,7 +34,7 @@ internal class IssueExternalOrderNumberUseCaseTest {
     @Test
     fun `it returns registered orderId and orderNumber`() {
         every { repository.findByOrderNumber(any()) } returns emptyList()
-        every { registerOrder.invoke(any(), any(), any(), any(), any(), any()) } returns Ok(order)
+        every { registerOrder.invoke(any(), any(), any(), any(), any(), null, null, any()) } returns Ok(order)
 
         assertThat(underTest(notificationUrl, Sample.SALIVA, null).unwrap()).isEqualTo(order)
     }
@@ -46,17 +46,39 @@ internal class IssueExternalOrderNumberUseCaseTest {
             listOf(orderInformation, orderInformation),
             emptyList()
         )
-        every { registerOrder.invoke(any(), any(), any(), any(), any(), any()) } returns Ok(order)
+        every {
+            registerOrder.invoke(
+                orderNumber = any(),
+                testSiteId = any(),
+                sample = any(),
+                notificationUrl = any(),
+                verificationSecret = any(),
+                sampledAt = any(),
+                metadata = any(),
+                now = any()
+            )
+        } returns Ok(order)
 
         underTest(notificationUrl, Sample.SALIVA, null)
 
-        verify { registerOrder.invoke(any(), null, any(), notificationUrl, any(), null) }
+        verify {
+            registerOrder.invoke(
+                orderNumber = any(),
+                testSiteId = null,
+                sample = Sample.SALIVA,
+                notificationUrl = notificationUrl,
+                verificationSecret = null,
+                sampledAt = null,
+                metadata = null,
+                now = any()
+            )
+        }
     }
 
     @Test
     fun `it calls registerOrder with default sample type SALIVA`() {
         every { repository.findByOrderNumber(any()) } returns emptyList()
-        every { registerOrder.invoke(any(), any(), any(), any(), any(), any()) } returns Ok(order)
+        every { registerOrder.invoke(any(), any(), any(), any(), any(), null, null, any()) } returns Ok(order)
 
         underTest(notificationUrl, Sample.SALIVA, null)
 
@@ -66,8 +88,10 @@ internal class IssueExternalOrderNumberUseCaseTest {
                 testSiteId = any(),
                 sample = Sample.SALIVA,
                 notificationUrl = any(),
-                now = any(),
-                verificationSecret = null
+                verificationSecret = null,
+                sampledAt = null,
+                metadata = null,
+                now = any()
             )
         }
     }

--- a/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/order/PreIssuedOrderNumberControllerTest.kt
@@ -1,6 +1,7 @@
 package com.healthmetrix.labres.order
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -40,6 +41,10 @@ class PreIssuedOrderNumberControllerTest {
     private val orderNumber = OrderNumber.from(issuerId, orderNumberString)
     private val testSiteId = "testSiteA"
     private val notificationUrl = "http://callme.test"
+    private val sampledAt = 1596186947L
+    private val metadata = JsonNodeFactory.instance.objectNode().apply {
+        put("hello", "world")
+    }
     private val order = OrderInformation(
         id = orderId,
         orderNumber = orderNumber,
@@ -51,6 +56,18 @@ class PreIssuedOrderNumberControllerTest {
     @BeforeEach
     internal fun setUp() {
         clearAllMocks()
+        every {
+            registerOrderUseCase.invoke(
+                orderNumber = any(),
+                testSiteId = any(),
+                sample = any(),
+                notificationUrl = any(),
+                verificationSecret = any(),
+                sampledAt = any(),
+                metadata = any(),
+                now = any()
+            )
+        } returns Ok(order)
     }
 
     @Nested
@@ -58,12 +75,29 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `registering a preissued order number returns status 201`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
+            val request = PreIssuedOrderNumberController.RegisterOrderRequest(
+                orderNumber = orderNumberString,
+                testSiteId = null,
+                notificationUrl = null
+            )
 
+            mockMvc.post("/v1/issuers/$issuerId/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated }
+            }
+        }
+
+        @Test
+        fun `registering a preissued order number with all optional parameters returns status 201`() {
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = orderNumberString,
                 testSiteId = testSiteId,
-                notificationUrl = notificationUrl
+                notificationUrl = notificationUrl,
+                sampledAt = sampledAt,
+                metadata = metadata,
+                sample = Sample.BLOOD
             )
 
             mockMvc.post("/v1/issuers/$issuerId/orders") {
@@ -76,8 +110,6 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `registering a preissued order number for kevb with more than 8 digits truncates the analyt`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
-
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = "0123456799",
                 testSiteId = testSiteId,
@@ -91,14 +123,21 @@ class PreIssuedOrderNumberControllerTest {
 
             val correct = OrderNumber.from("kevb", "01234567")
             verify(exactly = 1) {
-                registerOrderUseCase.invoke(eq(correct), any(), any(), any(), any(), null)
+                registerOrderUseCase.invoke(
+                    orderNumber = eq(correct),
+                    testSiteId = any(),
+                    sample = any(),
+                    notificationUrl = any(),
+                    verificationSecret = any(),
+                    sampledAt = any(),
+                    metadata = any(),
+                    now = any()
+                )
             }
         }
 
         @Test
         fun `registering a preissued order number returns order number and id`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
-
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = orderNumberString,
                 testSiteId = null,
@@ -115,8 +154,39 @@ class PreIssuedOrderNumberControllerTest {
         }
 
         @Test
+        fun `registering a preissued order number with all optional parameters returns order number and id`() {
+            val request = PreIssuedOrderNumberController.RegisterOrderRequest(
+                orderNumber = orderNumberString,
+                testSiteId = testSiteId,
+                notificationUrl = notificationUrl,
+                sampledAt = sampledAt,
+                metadata = metadata,
+                sample = Sample.BLOOD
+            )
+
+            mockMvc.post("/v1/issuers/$issuerId/orders") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                jsonPath("$.orderNumber") { isString }
+                jsonPath("$.id") { isString }
+            }
+        }
+
+        @Test
         fun `registering a preissued order number returns 409 if it has already been registered before`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Err("already exists")
+            every {
+                registerOrderUseCase.invoke(
+                    orderNumber = any(),
+                    testSiteId = any(),
+                    sample = any(),
+                    notificationUrl = any(),
+                    verificationSecret = any(),
+                    sampledAt = any(),
+                    metadata = any(),
+                    now = any()
+                )
+            } returns Err("already exists")
 
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
                 orderNumber = orderNumberString,
@@ -235,8 +305,6 @@ class PreIssuedOrderNumberControllerTest {
 
         @Test
         fun `registering a preissued order number for for issuerId hpi should transform it to mvz`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
-
             val issuerId = "hpi"
 
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
@@ -252,14 +320,21 @@ class PreIssuedOrderNumberControllerTest {
 
             val expected = OrderNumber.from("mvz", "01234567")
             verify(exactly = 1) {
-                registerOrderUseCase.invoke(eq(expected), any(), any(), any(), any(), any())
+                registerOrderUseCase.invoke(
+                    orderNumber = eq(expected),
+                    testSiteId = any(),
+                    sample = any(),
+                    notificationUrl = any(),
+                    verificationSecret = any(),
+                    sampledAt = any(),
+                    metadata = any(),
+                    now = any()
+                )
             }
         }
 
         @Test
         fun `registering a preissued order number for for issuerId wmt should transform it to mvz`() {
-            every { registerOrderUseCase.invoke(any(), any(), any(), any(), any(), null) } returns Ok(order)
-
             val issuerId = "wmt"
 
             val request = PreIssuedOrderNumberController.RegisterOrderRequest(
@@ -275,7 +350,16 @@ class PreIssuedOrderNumberControllerTest {
 
             val expected = OrderNumber.from("mvz", "01234567")
             verify(exactly = 1) {
-                registerOrderUseCase.invoke(eq(expected), any(), any(), any(), any(), any())
+                registerOrderUseCase.invoke(
+                    orderNumber = eq(expected),
+                    testSiteId = any(),
+                    sample = any(),
+                    notificationUrl = any(),
+                    verificationSecret = any(),
+                    sampledAt = any(),
+                    metadata = any(),
+                    now = any()
+                )
             }
         }
 

--- a/src/test/kotlin/com/healthmetrix/labres/persistence/RawOrderInformationTest.kt
+++ b/src/test/kotlin/com/healthmetrix/labres/persistence/RawOrderInformationTest.kt
@@ -1,5 +1,6 @@
 package com.healthmetrix.labres.persistence
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.healthmetrix.labres.lab.TestType
 import com.healthmetrix.labres.order.OrderNumber
 import com.healthmetrix.labres.order.Sample
@@ -27,6 +28,9 @@ internal class RawOrderInformationTest {
     private val orderNumberString = "1234567890"
     private val sampledAt = 1596186947L
     private val verificationSecret = UUID.randomUUID().toString()
+    private val metadata = JsonNodeFactory.instance.objectNode().apply {
+        put("hello", "world")
+    }
 
     private val raw = RawOrderInformation(
         id = id,
@@ -43,7 +47,8 @@ internal class RawOrderInformationTest {
         reportedAt = reportedAt,
         notifiedAt = notifiedAt,
         sampledAt = sampledAt,
-        verificationSecret = verificationSecret
+        verificationSecret = verificationSecret,
+        metadata = metadata
     )
 
     private val cooked = OrderInformation(
@@ -60,7 +65,8 @@ internal class RawOrderInformationTest {
         enteredLabAt = enteredLabAt,
         sample = Sample.BLOOD,
         sampledAt = sampledAt,
-        verificationSecret = verificationSecret
+        verificationSecret = verificationSecret,
+        metadata = metadata
     )
 
     @Nested
@@ -82,7 +88,8 @@ internal class RawOrderInformationTest {
                 testType = null,
                 enteredLabAt = null,
                 sampledAt = null,
-                verificationSecret = null
+                verificationSecret = null,
+                metadata = null
             ).cook()
 
             val expected = cooked.copy(
@@ -94,7 +101,8 @@ internal class RawOrderInformationTest {
                 testType = null,
                 enteredLabAt = null,
                 sampledAt = null,
-                verificationSecret = null
+                verificationSecret = null,
+                metadata = null
             )
 
             assertThat(result).isEqualTo(expected)
@@ -211,7 +219,8 @@ internal class RawOrderInformationTest {
                 enteredLabAt = null,
                 testType = null,
                 sampledAt = null,
-                verificationSecret = null
+                verificationSecret = null,
+                metadata = null
             ).raw()
 
             val expected = raw.copy(
@@ -223,7 +232,8 @@ internal class RawOrderInformationTest {
                 testType = null,
                 enteredLabAt = null,
                 sampledAt = null,
-                verificationSecret = null
+                verificationSecret = null,
+                metadata = null
             )
 
             assertThat(result).isEqualTo(expected)


### PR DESCRIPTION
- Add property metadata that can take in any valid json to be persisted with a preissued order
- Introduce AbstractIntegrationTest to simplify addition of further integration test flows
